### PR TITLE
Merge People Search and Suggestions

### DIFF
--- a/IceFishing/AppDelegate.swift
+++ b/IceFishing/AppDelegate.swift
@@ -24,7 +24,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, SWRevealViewControllerDel
 	let profileVC = ProfileViewController(nibName: "ProfileViewController", bundle: nil)
 	let likedVC = LikedTableViewController()
 	let spotifyVC = SpotifyViewController(nibName: "SpotifyViewController", bundle: nil)
-	let suggestionsVC = FollowSuggestionTableViewController()
 	let navigationController = UINavigationController()
 	
 	//slack info
@@ -110,8 +109,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, SWRevealViewControllerDel
 				SideBarElement(title: "Feed", viewController: feedVC, image: UIImage(named: "Feed")),
 				SideBarElement(title: "People", viewController: usersVC, image: UIImage(named: "People")),
 				SideBarElement(title: "Liked", viewController: likedVC, image: UIImage(named: "Heart-Menu")),
-				SideBarElement(title: "Spotify", viewController: spotifyVC, image: UIImage(named: "Spotify")),
-				SideBarElement(title: "Suggestions", viewController: suggestionsVC, image: UIImage(named: "People")),
+				SideBarElement(title: "Spotify", viewController: spotifyVC, image: UIImage(named: "Spotify"))
 			]
 			sidebarVC.selectionHandler = {
 				[weak self]

--- a/IceFishing/Controllers/PlayerTableViewController.swift
+++ b/IceFishing/Controllers/PlayerTableViewController.swift
@@ -92,8 +92,8 @@ class PlayerTableViewController: UITableViewController, UISearchResultsUpdating,
 	}
 	
 	func navigateToSuggestions() {
-		let suggestionsVC = (UIApplication.sharedApplication().delegate as! AppDelegate).suggestionsVC
-		navigationController?.setViewControllers([suggestionsVC], animated: false)
+		let usersVC = (UIApplication.sharedApplication().delegate as! AppDelegate).usersVC
+		navigationController?.setViewControllers([usersVC], animated: false)
 	}
 	
     private func updateNowPlayingInfo() {

--- a/IceFishing/Profile/FollowTableViewCell.swift
+++ b/IceFishing/Profile/FollowTableViewCell.swift
@@ -8,6 +8,10 @@
 
 import UIKit
 
+protocol FollowUserDelegate {
+	func didTapFollowButton(cell: FollowTableViewCell)
+}
+
 class FollowTableViewCell: UITableViewCell {
     
     @IBOutlet weak var userImage: UIImageView!
@@ -15,6 +19,9 @@ class FollowTableViewCell: UITableViewCell {
     @IBOutlet weak var userHandle: UILabel!
     @IBOutlet weak var numFollowLabel: UILabel!
     @IBOutlet weak var separator: UIView!
+	@IBOutlet weak var followButton: UIButton!
+	
+	var delegate: FollowUserDelegate?
     
     override func didMoveToSuperview() {
         selectionStyle = .None
@@ -35,5 +42,9 @@ class FollowTableViewCell: UITableViewCell {
     override func setSelected(selected: Bool, animated: Bool) {
 		contentView.backgroundColor = selected ? UIColor.iceLightGray : UIColor.clearColor()
     }
+	
+	@IBAction func didTapFollowButton(sender: AnyObject) {
+		delegate?.didTapFollowButton(self)
+	}
 }
 

--- a/IceFishing/Profile/FollowTableViewCell.xib
+++ b/IceFishing/Profile/FollowTableViewCell.xib
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9046" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9035"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <customFonts key="customFonts">
         <mutableArray key="AvenirNext.ttc">
             <string>AvenirNext-Regular</string>
             <string>AvenirNext-Medium</string>
+            <string>AvenirNext-Regular</string>
             <string>AvenirNext-Regular</string>
         </mutableArray>
     </customFonts>
@@ -54,6 +55,16 @@
                             <constraint firstAttribute="height" constant="45" id="ZTu-wb-jTM"/>
                         </constraints>
                     </imageView>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="esL-gW-6wl">
+                        <rect key="frame" x="300" y="37" width="39" height="30"/>
+                        <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="13"/>
+                        <state key="normal" title="Follow">
+                            <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                        </state>
+                        <connections>
+                            <action selector="didTapFollowButton:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="ugn-XV-tkf"/>
+                        </connections>
+                    </button>
                 </subviews>
                 <color key="backgroundColor" red="0.13725490196078433" green="0.14117647058823529" blue="0.15294117647058825" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 <color key="tintColor" red="0.23244757399999999" green="1" blue="0.20392156859999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -62,11 +73,13 @@
                     <constraint firstItem="RHF-ja-uAd" firstAttribute="bottom" secondItem="8sn-Jc-sON" secondAttribute="bottom" constant="3" id="91v-C9-oIU"/>
                     <constraint firstItem="YKr-CE-jlM" firstAttribute="top" secondItem="8sn-Jc-sON" secondAttribute="top" constant="-6" id="Kds-dW-z9j"/>
                     <constraint firstItem="YKr-CE-jlM" firstAttribute="leading" secondItem="RHF-ja-uAd" secondAttribute="leading" id="Qry-BM-hi0"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="esL-gW-6wl" secondAttribute="trailing" constant="1" id="Sob-qb-LuO"/>
                     <constraint firstAttribute="bottom" secondItem="4aW-FM-QRN" secondAttribute="bottom" id="Ygp-mX-41C"/>
                     <constraint firstItem="uOI-Pn-Mde" firstAttribute="centerY" secondItem="8sn-Jc-sON" secondAttribute="centerY" id="bJi-Wh-8fo"/>
                     <constraint firstItem="uOI-Pn-Mde" firstAttribute="top" secondItem="YKr-CE-jlM" secondAttribute="bottom" constant="-1" id="caW-1R-j8a"/>
                     <constraint firstItem="uOI-Pn-Mde" firstAttribute="top" secondItem="YKr-CE-jlM" secondAttribute="bottom" constant="-3" id="gki-D7-0gr"/>
                     <constraint firstItem="RHF-ja-uAd" firstAttribute="top" secondItem="uOI-Pn-Mde" secondAttribute="bottom" constant="8" symbolic="YES" id="gtp-2c-pMc"/>
+                    <constraint firstItem="esL-gW-6wl" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="hyN-eO-KEa"/>
                     <constraint firstAttribute="bottomMargin" secondItem="4aW-FM-QRN" secondAttribute="bottom" id="n87-8J-Ooa"/>
                     <constraint firstItem="8sn-Jc-sON" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" constant="5" id="qEu-86-r7S"/>
                     <constraint firstItem="4aW-FM-QRN" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="rWp-TH-uOL"/>
@@ -88,6 +101,7 @@
             <color key="backgroundColor" red="0.17254901960784313" green="0.17647058823529413" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <inset key="separatorInset" minX="5" minY="0.0" maxX="0.0" maxY="0.0"/>
             <connections>
+                <outlet property="followButton" destination="esL-gW-6wl" id="Gg6-TA-Qwf"/>
                 <outlet property="numFollowLabel" destination="RHF-ja-uAd" id="rKP-Ln-qhu"/>
                 <outlet property="separator" destination="4aW-FM-QRN" id="8ny-YP-nCb"/>
                 <outlet property="userHandle" destination="uOI-Pn-Mde" id="E50-0H-wSc"/>

--- a/IceFishing/Profile/UsersViewController.swift
+++ b/IceFishing/Profile/UsersViewController.swift
@@ -129,8 +129,13 @@ class UsersViewController: UITableViewController, UISearchResultsUpdating, UISea
         user.loadImage {
             cell.userImage.image = $0
         }
-		cell.followButton.setTitle(self.user.isFollowing ? "Following" : "Follow", forState: .Normal)
-		cell.delegate = self
+		if user.id != User.currentUser.id {
+			cell.followButton.setTitle(user.isFollowing ? "Following" : "Follow", forState: .Normal)
+			cell.delegate = self
+		} else {
+			cell.followButton.setTitle("", forState: .Normal)
+		}
+		
         
         return cell
     }
@@ -191,11 +196,15 @@ class UsersViewController: UITableViewController, UISearchResultsUpdating, UISea
 			user = searchController.active ? filteredUsers[indexPath!.row] : users[indexPath!.row]
 		}
 		
+		if user.id == User.currentUser.id {
+			return
+		}
+		
 		user.isFollowing = !user.isFollowing
 		User.currentUser.followingCount += user.isFollowing ? 1 : -1
 		user.followersCount += user.isFollowing ? 1 : -1
 		let cell = tableView.cellForRowAtIndexPath(indexPath!) as! FollowTableViewCell
-		cell.followButton.setTitle(self.user.isFollowing ? "Following" : "Follow", forState: .Normal)
+		cell.followButton.setTitle(user.isFollowing ? "Following" : "Follow", forState: .Normal)
 		API.sharedAPI.updateFollowings(user.id, unfollow: !user.isFollowing)
 		dispatch_async(dispatch_get_main_queue()) {
 			self.tableView.reloadData()

--- a/IceFishing/Profile/UsersViewController.swift
+++ b/IceFishing/Profile/UsersViewController.swift
@@ -23,7 +23,7 @@ class UsersViewController: UITableViewController, UISearchResultsUpdating, UISea
 	private var filteredUsers: [User] = []
 	private var searchController: UISearchController!
 	var isLoadingMoreSuggestions = false
-	let length = 8
+	let length = 10
 	var page = 0
 
     override func viewDidLoad() {
@@ -201,25 +201,16 @@ class UsersViewController: UITableViewController, UISearchResultsUpdating, UISea
 	}()
 	
 	func willPresentSearchController(searchController: UISearchController) {
-		let completion: [User] -> Void = {
-			self.users = $0
-			self.tableView.reloadData()
-			
-			if self.users.count == 0 {
-				switch self.displayType {
-				case .Followers:
-					self.tableView.backgroundView = UIView.viewForEmptyViewController(.Followers, size: self.view.bounds.size, isCurrentUser: (self.user.id == User.currentUser.id), userFirstName: self.user.firstName)
-				case .Following:
-					self.tableView.backgroundView = UIView.viewForEmptyViewController(.Following, size: self.view.bounds.size, isCurrentUser: (self.user.id == User.currentUser.id), userFirstName: self.user.firstName)
-				default:
-					self.tableView.backgroundView = UIView.viewForEmptyViewController(.Users, size: self.view.bounds.size, isCurrentUser: (self.user.id == User.currentUser.id), userFirstName: self.user.firstName)
-				}
-			} else {
-				self.tableView.backgroundView = nil
+		// if a .Users VC, only suggestions were fetched in viewDidLoad(), need to fetch users to search
+		if displayType == .Users {
+			let completion: [User] -> Void = {
+				self.users = $0
+				self.tableView.reloadData()
+				self.filterContentForSearchText("")
 			}
+			
+			API.sharedAPI.searchUsers("", completion: completion)
 		}
-		
-		API.sharedAPI.searchUsers("", completion: completion)
 		
 		navigationController?.view.addSubview(statusBarView)
 	}


### PR DESCRIPTION
Addresses #11 to merge suggestions into the users view controller to consolidate suggestions and people searches into one location. When search bar is not active, the users view controller acts as a suggestions VC. When it becomes active, allows a user to search the user database. Followers and Following display types for UsersVC operate as before, but each cell gains a follow button so a user can follow and unfollow users anywhere a UsersVC is presented.

I'm currently waiting on backend to implement is_following flag, which will allow my feature to work. I was unable to test the final branch because of this, but it should work once this is implemented on the backend.

Also, I chose not to delete the FollowSuggestionsTableViewController and the FollowSuggestionCell files in case we need these later (even though there are not used anywhere in my new feature branch). However, I can delete these if it helps keep the project readable and uncluttered.
