### PR TITLE
Jesse/fix pin

### DIFF
--- a/IceFishing/Controllers/FeedViewController.swift
+++ b/IceFishing/Controllers/FeedViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import MediaPlayer
 
-class FeedViewController: PlayerTableViewController, SongSearchDelegate, PostViewDelegate {
+class FeedViewController: PlayerTableViewController, SongSearchDelegate {
 	
 	var customRefresh: ADRefreshControl?
 	var plusButton: UIButton!
@@ -120,7 +120,6 @@ class FeedViewController: PlayerTableViewController, SongSearchDelegate, PostVie
 		cell.postView.post = posts[indexPath.row]
 		cell.postView.post?.player.prepareToPlay()
 		cell.postView.delegate = self
-		cell.postView.playerController = self as PlayerTableViewController
 		return cell
 	}
 	

--- a/IceFishing/Controllers/FeedViewController.swift
+++ b/IceFishing/Controllers/FeedViewController.swift
@@ -120,6 +120,7 @@ class FeedViewController: PlayerTableViewController, SongSearchDelegate, PostVie
 		cell.postView.post = posts[indexPath.row]
 		cell.postView.post?.player.prepareToPlay()
 		cell.postView.delegate = self
+		cell.postView.playerController = self as PlayerTableViewController
 		return cell
 	}
 	

--- a/IceFishing/Controllers/LikedTableViewController.swift
+++ b/IceFishing/Controllers/LikedTableViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class LikedTableViewController: PlayerTableViewController, PostViewDelegate {
+class LikedTableViewController: PlayerTableViewController {
     let cellIdentifier = "FeedTableViewCell"
     
     override func viewDidLoad() {
@@ -49,7 +49,6 @@ class LikedTableViewController: PlayerTableViewController, PostViewDelegate {
 		let posts = searchController.active ? filteredPosts : self.posts
 		cell.postView.post = posts[indexPath.row]
 		cell.postView.delegate = self
-		cell.postView.playerController = self as PlayerTableViewController
 		print("asign player controller")
 		cell.postView.post?.player.prepareToPlay()
 		

--- a/IceFishing/Controllers/LikedTableViewController.swift
+++ b/IceFishing/Controllers/LikedTableViewController.swift
@@ -49,6 +49,8 @@ class LikedTableViewController: PlayerTableViewController, PostViewDelegate {
 		let posts = searchController.active ? filteredPosts : self.posts
 		cell.postView.post = posts[indexPath.row]
 		cell.postView.delegate = self
+		cell.postView.playerController = self as PlayerTableViewController
+		print("asign player controller")
 		cell.postView.post?.player.prepareToPlay()
 		
 		return cell

--- a/IceFishing/Controllers/LikedTableViewController.swift
+++ b/IceFishing/Controllers/LikedTableViewController.swift
@@ -20,8 +20,6 @@ class LikedTableViewController: PlayerTableViewController {
 		definesPresentationContext = true
 		tableView.registerNib(UINib(nibName: cellIdentifier, bundle: nil), forCellReuseIdentifier: "FeedCell")
 		
-		notifCenterSetup()
-		commandCenterHandler()
 		addHamburgerMenu()
 
 		// Fix color above search bar
@@ -49,7 +47,6 @@ class LikedTableViewController: PlayerTableViewController {
 		let posts = searchController.active ? filteredPosts : self.posts
 		cell.postView.post = posts[indexPath.row]
 		cell.postView.delegate = self
-		print("asign player controller")
 		cell.postView.post?.player.prepareToPlay()
 		
 		return cell

--- a/IceFishing/Controllers/PlayerTableViewController+Pinning.swift
+++ b/IceFishing/Controllers/PlayerTableViewController+Pinning.swift
@@ -11,7 +11,6 @@ import UIKit
 extension PlayerTableViewController {
 	
 	internal func setupPinViews() {
-		//pinViewGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(PlayerTableViewController.togglePlay))
 		pinView.backgroundColor = UIColor.iceLightGray
 		pinView.postView.delegate = self
 	}
@@ -34,7 +33,6 @@ extension PlayerTableViewController {
 	
 	func pinIfNeeded() {
 		guard let selected = currentlyPlayingIndexPath else { return }
-		pinnedIndexPath = currentlyPlayingIndexPath
 		if pinView.postView.post != posts[selected.row] {
 			pinView.postView.post = posts[selected.row]
 		}
@@ -50,11 +48,6 @@ extension PlayerTableViewController {
 			topPinViewContainer.hidden = true
 			bottomPinViewContainer.hidden = true
 		}
-	}
-	
-	func updatePlayInfo() {
-		currentlyPlayingIndexPath = pinnedIndexPath
-		currentlyPlayingPost = pinView.postView.post
 	}
 	
 	override func scrollViewDidScroll(scrollView: UIScrollView) {

--- a/IceFishing/Controllers/PlayerTableViewController+Pinning.swift
+++ b/IceFishing/Controllers/PlayerTableViewController+Pinning.swift
@@ -12,7 +12,8 @@ extension PlayerTableViewController {
 	
 	internal func setupPinViews() {
 		pinViewGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(PlayerTableViewController.togglePlay))
-		pinViewGestureRecognizer.delegate = pinView.postView
+		transparentTopPinViewContainer.userInteractionEnabled = true
+		transparentTopPinViewContainer.addGestureRecognizer(pinViewGestureRecognizer)
 		pinView.backgroundColor = UIColor.iceLightGray
 	}
 	
@@ -21,25 +22,31 @@ extension PlayerTableViewController {
 		let myFrame = view.frame
 		
 		topPinViewContainer.frame = CGRectMake(0, frame.minY + tableView.contentInset.top, myFrame.width, tableView.rowHeight)
+		transparentTopPinViewContainer.frame = CGRectMake(0, frame.minY + tableView.contentInset.top, myFrame.width, tableView.rowHeight)
 		bottomPinViewContainer.frame = CGRectMake(0, frame.maxY - tableView.rowHeight, myFrame.width, tableView.rowHeight)
 		
 		view.superview!.addSubview(topPinViewContainer)
 		view.superview!.addSubview(bottomPinViewContainer)
+		view.superview!.addSubview(transparentTopPinViewContainer)
 		
 		topPinViewContainer.hidden = true
+		transparentTopPinViewContainer.hidden = true
 		bottomPinViewContainer.hidden = true
 		
 		pinView.frame = CGRectMake(0, 0, view.frame.width, tableView.rowHeight)
+		transparentTopPinViewContainer.backgroundColor = UIColor.clearColor()
 	}
 	
 	func pinIfNeeded() {
 		guard let selected = currentlyPlayingIndexPath else { return }
+		pinnedIndexPath = currentlyPlayingIndexPath
 		if pinView.postView.post != posts[selected.row] {
 			pinView.postView.post = posts[selected.row]
 		}
 		guard let selectedCell = tableView.cellForRowAtIndexPath(selected) else { return }
 		if selectedCell.frame.minY < tableView.contentOffset.y {
 			topPinViewContainer.addSubview(pinView)
+			transparentTopPinViewContainer.hidden = false
 			topPinViewContainer.hidden = false
 		} else if selectedCell.frame.maxY > tableView.contentOffset.y + tableView.frame.height {
 			pinView.postView.post = posts[selected.row]
@@ -47,12 +54,15 @@ extension PlayerTableViewController {
 			bottomPinViewContainer.hidden = false
 		} else {
 			topPinViewContainer.hidden = true
+			transparentTopPinViewContainer.hidden = true
 			bottomPinViewContainer.hidden = true
 		}
 	}
 	
 	func togglePlay() {
-		pinView.postView.post?.player.togglePlaying()
+		currentlyPlayingIndexPath = pinnedIndexPath
+		print(currentlyPlayingIndexPath?.row)
+		currentlyPlayingPost = pinView.postView.post
 	}
 	
 	override func scrollViewDidScroll(scrollView: UIScrollView) {

--- a/IceFishing/Controllers/PlayerTableViewController+Pinning.swift
+++ b/IceFishing/Controllers/PlayerTableViewController+Pinning.swift
@@ -11,10 +11,9 @@ import UIKit
 extension PlayerTableViewController {
 	
 	internal func setupPinViews() {
-		pinViewGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(PlayerTableViewController.togglePlay))
-		transparentTopPinViewContainer.userInteractionEnabled = true
-		transparentTopPinViewContainer.addGestureRecognizer(pinViewGestureRecognizer)
+		//pinViewGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(PlayerTableViewController.togglePlay))
 		pinView.backgroundColor = UIColor.iceLightGray
+		pinView.postView.playerController = self as PlayerTableViewController
 	}
 	
 	internal func positionPinViews() {
@@ -22,31 +21,28 @@ extension PlayerTableViewController {
 		let myFrame = view.frame
 		
 		topPinViewContainer.frame = CGRectMake(0, frame.minY + tableView.contentInset.top, myFrame.width, tableView.rowHeight)
-		transparentTopPinViewContainer.frame = CGRectMake(0, frame.minY + tableView.contentInset.top, myFrame.width, tableView.rowHeight)
 		bottomPinViewContainer.frame = CGRectMake(0, frame.maxY - tableView.rowHeight, myFrame.width, tableView.rowHeight)
 		
 		view.superview!.addSubview(topPinViewContainer)
 		view.superview!.addSubview(bottomPinViewContainer)
-		view.superview!.addSubview(transparentTopPinViewContainer)
 		
 		topPinViewContainer.hidden = true
-		transparentTopPinViewContainer.hidden = true
 		bottomPinViewContainer.hidden = true
 		
 		pinView.frame = CGRectMake(0, 0, view.frame.width, tableView.rowHeight)
-		transparentTopPinViewContainer.backgroundColor = UIColor.clearColor()
 	}
 	
 	func pinIfNeeded() {
 		guard let selected = currentlyPlayingIndexPath else { return }
 		pinnedIndexPath = currentlyPlayingIndexPath
 		if pinView.postView.post != posts[selected.row] {
+//			let cell = tableView.cellForRowAtIndexPath(selected) as! FeedTableViewCell
+//			pinView.postView = cell.postView
 			pinView.postView.post = posts[selected.row]
 		}
 		guard let selectedCell = tableView.cellForRowAtIndexPath(selected) else { return }
 		if selectedCell.frame.minY < tableView.contentOffset.y {
 			topPinViewContainer.addSubview(pinView)
-			transparentTopPinViewContainer.hidden = false
 			topPinViewContainer.hidden = false
 		} else if selectedCell.frame.maxY > tableView.contentOffset.y + tableView.frame.height {
 			pinView.postView.post = posts[selected.row]
@@ -54,14 +50,12 @@ extension PlayerTableViewController {
 			bottomPinViewContainer.hidden = false
 		} else {
 			topPinViewContainer.hidden = true
-			transparentTopPinViewContainer.hidden = true
 			bottomPinViewContainer.hidden = true
 		}
 	}
 	
-	func togglePlay() {
+	func updatePlayInfo() {
 		currentlyPlayingIndexPath = pinnedIndexPath
-		print(currentlyPlayingIndexPath?.row)
 		currentlyPlayingPost = pinView.postView.post
 	}
 	

--- a/IceFishing/Controllers/PlayerTableViewController+Pinning.swift
+++ b/IceFishing/Controllers/PlayerTableViewController+Pinning.swift
@@ -13,7 +13,7 @@ extension PlayerTableViewController {
 	internal func setupPinViews() {
 		//pinViewGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(PlayerTableViewController.togglePlay))
 		pinView.backgroundColor = UIColor.iceLightGray
-		pinView.postView.playerController = self as PlayerTableViewController
+		pinView.postView.delegate = self
 	}
 	
 	internal func positionPinViews() {
@@ -36,8 +36,6 @@ extension PlayerTableViewController {
 		guard let selected = currentlyPlayingIndexPath else { return }
 		pinnedIndexPath = currentlyPlayingIndexPath
 		if pinView.postView.post != posts[selected.row] {
-//			let cell = tableView.cellForRowAtIndexPath(selected) as! FeedTableViewCell
-//			pinView.postView = cell.postView
 			pinView.postView.post = posts[selected.row]
 		}
 		guard let selectedCell = tableView.cellForRowAtIndexPath(selected) else { return }

--- a/IceFishing/Controllers/PlayerTableViewController.swift
+++ b/IceFishing/Controllers/PlayerTableViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import MediaPlayer
 
-class PlayerTableViewController: UITableViewController, UISearchResultsUpdating, UISearchControllerDelegate, UISearchBarDelegate {
+class PlayerTableViewController: UITableViewController, UISearchResultsUpdating, UISearchControllerDelegate, UISearchBarDelegate, PostViewDelegate {
 	// For pinning
 	let topPinViewContainer = UIView()
 	let bottomPinViewContainer = UIView()

--- a/IceFishing/Controllers/PlayerTableViewController.swift
+++ b/IceFishing/Controllers/PlayerTableViewController.swift
@@ -14,38 +14,17 @@ class PlayerTableViewController: UITableViewController, UISearchResultsUpdating,
 	let topPinViewContainer = UIView()
 	let bottomPinViewContainer = UIView()
 	let pinView = NSBundle.mainBundle().loadNibNamed("FeedTableViewCell", owner: nil, options: nil)[0] as! FeedTableViewCell
-	var pinnedIndexPath: NSIndexPath?
-	var pinViewGestureRecognizer: UITapGestureRecognizer!
 	
 	var searchController: UISearchController!
 	var posts: [Post] = []
 	var filteredPosts: [Post] = []
     var currentlyPlayingPost: Post?
 	
-    var currentlyPlayingIndexPath: NSIndexPath? {
-        didSet {
-			var array = posts
-			if searchController.active {
-				array = filteredPosts
-			}
-            if let row = currentlyPlayingIndexPath?.row where currentlyPlayingPost?.isEqual(array[row]) ?? false {
-                //currentlyPlayingPost?.player.togglePlaying()
-            } else {
-                //currentlyPlayingPost?.player.pause(true)
-                //currentlyPlayingPost?.player.progress = 1.0 // Fill cell as played
-                
-                if let currentlyPlayingIndexPath = currentlyPlayingIndexPath {
-                    currentlyPlayingPost = array[currentlyPlayingIndexPath.row]
-                    //currentlyPlayingPost!.player.play(true)
-                } else {
-                    currentlyPlayingPost = nil
-                }
-            }
-            tableView.selectRowAtIndexPath(currentlyPlayingIndexPath, animated: false, scrollPosition: .None)
-        }
-    }
+    var currentlyPlayingIndexPath: NSIndexPath?
 
 	var savedSongAlertView: SavedSongView!
+	
+	var justOpened = true
 	
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -67,6 +46,7 @@ class PlayerTableViewController: UITableViewController, UISearchResultsUpdating,
 		tableView.backgroundView = UIView() // Fix color above search bar
 		
 		setupPinViews()
+		notifCenterSetup()
     }
 	
 	override func viewDidAppear(animated: Bool) {
@@ -74,6 +54,7 @@ class PlayerTableViewController: UITableViewController, UISearchResultsUpdating,
 		
 		positionPinViews()
 		addRevealGesture()
+		justOpened = true
 	}
 	
 	override func viewDidDisappear(animated: Bool) {
@@ -95,6 +76,21 @@ class PlayerTableViewController: UITableViewController, UISearchResultsUpdating,
 	func navigateToSuggestions() {
 		let usersVC = (UIApplication.sharedApplication().delegate as! AppDelegate).usersVC
 		navigationController?.setViewControllers([usersVC], animated: false)
+	}
+	
+	func updatePlayInfo(post: Post) {
+		if justOpened {
+			removeCommandCenterHandler()
+			commandCenterHandler()
+			justOpened = false
+		}
+		
+		let array = (searchController.active) ? filteredPosts : posts
+		//A hacky solution to get indexPath
+		let indexPath = NSIndexPath(forRow: array.indexOf(post)!, inSection: 0)
+		currentlyPlayingIndexPath = indexPath
+		currentlyPlayingPost = post
+		updateNowPlayingInfo()
 	}
 	
     private func updateNowPlayingInfo() {
@@ -119,7 +115,6 @@ class PlayerTableViewController: UITableViewController, UISearchResultsUpdating,
 				if searchController.active {
 					count = filteredPosts.count
 				}
-				
                 center.nowPlayingInfo = [
                     MPMediaItemPropertyTitle: post.song.title,
                     MPMediaItemPropertyArtist: post.song.artist,
@@ -202,13 +197,18 @@ class PlayerTableViewController: UITableViewController, UISearchResultsUpdating,
         
         center.nextTrackCommand.addTargetWithHandler { [weak self] _ in
 			var count = self!.posts.count
-			if self!.searchController.active {
+			if self!.searchController.active {	
 				count = self!.filteredPosts.count
 			}
             if let path = self?.currentlyPlayingIndexPath {
                 if path.row < count - 1 {
                     self?.currentlyPlayingIndexPath = NSIndexPath(forRow: path.row + 1, inSection: path.section)
-                    return .Success
+					let array = (self!.searchController.active) ? self!.filteredPosts : self!.posts
+					self?.currentlyPlayingPost = array[path.row + 1]
+					if let player = self?.currentlyPlayingPost?.player {
+						player.play(true)
+						return .Success
+					}
                 }
             }
             return .NoSuchContent
@@ -218,8 +218,13 @@ class PlayerTableViewController: UITableViewController, UISearchResultsUpdating,
             if let path = self?.currentlyPlayingIndexPath {
                 if path.row > 0 {
                     self?.currentlyPlayingIndexPath = NSIndexPath(forRow: path.row - 1, inSection: path.section)
+					let array = (self!.searchController.active) ? self!.filteredPosts : self!.posts
+					self?.currentlyPlayingPost = array[path.row - 1]
+					if let player = self?.currentlyPlayingPost?.player {
+						player.play(true)
+						return .Success
+					}
                 }
-                return .Success
             }
             return .NoSuchContent
         }
@@ -227,6 +232,14 @@ class PlayerTableViewController: UITableViewController, UISearchResultsUpdating,
         center.seekForwardCommand.addTargetWithHandler { _ in .Success }
         center.seekBackwardCommand.addTargetWithHandler { _ in .Success }
     }
+	
+	func removeCommandCenterHandler() {
+		let center = MPRemoteCommandCenter.sharedCommandCenter()
+		center.playCommand.removeTarget(nil)
+		center.pauseCommand.removeTarget(nil)
+		center.nextTrackCommand.removeTarget(nil)
+		center.previousTrackCommand.removeTarget(nil)
+	}
 	
 	// MARK: - Search Stuff
 	

--- a/IceFishing/Controllers/PlayerTableViewController.swift
+++ b/IceFishing/Controllers/PlayerTableViewController.swift
@@ -12,8 +12,10 @@ import MediaPlayer
 class PlayerTableViewController: UITableViewController, UISearchResultsUpdating, UISearchControllerDelegate, UISearchBarDelegate {
 	// For pinning
 	let topPinViewContainer = UIView()
+	let transparentTopPinViewContainer = UIView()
 	let bottomPinViewContainer = UIView()
 	let pinView = NSBundle.mainBundle().loadNibNamed("FeedTableViewCell", owner: nil, options: nil)[0] as! FeedTableViewCell
+	var pinnedIndexPath: NSIndexPath?
 	var pinViewGestureRecognizer: UITapGestureRecognizer!
 	
 	var searchController: UISearchController!
@@ -31,7 +33,7 @@ class PlayerTableViewController: UITableViewController, UISearchResultsUpdating,
                 currentlyPlayingPost?.player.togglePlaying()
             } else {
                 currentlyPlayingPost?.player.pause(true)
-                currentlyPlayingPost?.player.progress = 1.0 // Fill cell as played
+                //currentlyPlayingPost?.player.progress = 1.0 // Fill cell as played
                 
                 if let currentlyPlayingIndexPath = currentlyPlayingIndexPath {
                     currentlyPlayingPost = array[currentlyPlayingIndexPath.row]

--- a/IceFishing/Controllers/PlayerTableViewController.swift
+++ b/IceFishing/Controllers/PlayerTableViewController.swift
@@ -12,7 +12,6 @@ import MediaPlayer
 class PlayerTableViewController: UITableViewController, UISearchResultsUpdating, UISearchControllerDelegate, UISearchBarDelegate {
 	// For pinning
 	let topPinViewContainer = UIView()
-	let transparentTopPinViewContainer = UIView()
 	let bottomPinViewContainer = UIView()
 	let pinView = NSBundle.mainBundle().loadNibNamed("FeedTableViewCell", owner: nil, options: nil)[0] as! FeedTableViewCell
 	var pinnedIndexPath: NSIndexPath?
@@ -30,14 +29,14 @@ class PlayerTableViewController: UITableViewController, UISearchResultsUpdating,
 				array = filteredPosts
 			}
             if let row = currentlyPlayingIndexPath?.row where currentlyPlayingPost?.isEqual(array[row]) ?? false {
-                currentlyPlayingPost?.player.togglePlaying()
+                //currentlyPlayingPost?.player.togglePlaying()
             } else {
-                currentlyPlayingPost?.player.pause(true)
+                //currentlyPlayingPost?.player.pause(true)
                 //currentlyPlayingPost?.player.progress = 1.0 // Fill cell as played
                 
                 if let currentlyPlayingIndexPath = currentlyPlayingIndexPath {
                     currentlyPlayingPost = array[currentlyPlayingIndexPath.row]
-                    currentlyPlayingPost!.player.play(true)
+                    //currentlyPlayingPost!.player.play(true)
                 } else {
                     currentlyPlayingPost = nil
                 }

--- a/IceFishing/Controllers/PostHistoryTableViewController.swift
+++ b/IceFishing/Controllers/PostHistoryTableViewController.swift
@@ -17,9 +17,6 @@ class PostHistoryTableViewController: PlayerTableViewController {
 	
     override func viewDidLoad() {
         super.viewDidLoad()
-	
-		notifCenterSetup()
-		commandCenterHandler()
 		
         tableView.separatorStyle = .None
         tableView.backgroundColor = UIColor.iceDarkGray

--- a/IceFishing/Controllers/PostHistoryTableViewController.swift
+++ b/IceFishing/Controllers/PostHistoryTableViewController.swift
@@ -53,6 +53,7 @@ class PostHistoryTableViewController: PlayerTableViewController, PostViewDelegat
 		let posts = searchController.active ? filteredPosts : self.posts
 		cell.postView.post = posts[indexPath.row]
 		cell.postView.delegate = self
+		cell.postView.playerController = self as PlayerTableViewController
 		cell.postView.post?.player.prepareToPlay()
 		
         let date = NSDateFormatter.simpleDateFormatter.stringFromDate(postedDates[indexPath.row])

--- a/IceFishing/Controllers/PostHistoryTableViewController.swift
+++ b/IceFishing/Controllers/PostHistoryTableViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import MediaPlayer
 
-class PostHistoryTableViewController: PlayerTableViewController, PostViewDelegate {
+class PostHistoryTableViewController: PlayerTableViewController {
 	
 	var songLikes: [Int] = []
     var postedDates: [NSDate] = []
@@ -53,7 +53,6 @@ class PostHistoryTableViewController: PlayerTableViewController, PostViewDelegat
 		let posts = searchController.active ? filteredPosts : self.posts
 		cell.postView.post = posts[indexPath.row]
 		cell.postView.delegate = self
-		cell.postView.playerController = self as PlayerTableViewController
 		cell.postView.post?.player.prepareToPlay()
 		
         let date = NSDateFormatter.simpleDateFormatter.stringFromDate(postedDates[indexPath.row])

--- a/IceFishing/Views/PostView.swift
+++ b/IceFishing/Views/PostView.swift
@@ -342,9 +342,7 @@ class PostView: UIView, UIGestureRecognizerDelegate {
 				delegate?.didTapImageForPostView?(self)
 			} else {
 				post.player.togglePlaying()
-				//print(playerController)
-				//playerController?.updatePlayInfo()
-				(delegate as! PlayerTableViewController).updatePlayInfo()
+				(delegate as! PlayerTableViewController).updatePlayInfo(post)
 			}
 		}
 	}

--- a/IceFishing/Views/PostView.swift
+++ b/IceFishing/Views/PostView.swift
@@ -46,6 +46,7 @@ class PostView: UIView, UIGestureRecognizerDelegate {
     var type: ViewType = .Feed
 	var songStatus: SavedSongStatus = .NotSaved
 	var delegate: PostViewDelegate?
+	var playerController: PlayerTableViewController?
     private var updateTimer: NSTimer?
     private var notificationHandler: AnyObject?
     
@@ -340,6 +341,10 @@ class PostView: UIView, UIGestureRecognizerDelegate {
 				}
 			} else if hitView == avatarImageView {
 				delegate?.didTapImageForPostView?(self)
+			} else {
+				post.player.togglePlaying()
+				print(playerController)
+				playerController?.updatePlayInfo()
 			}
 		}
 	}

--- a/IceFishing/Views/PostView.swift
+++ b/IceFishing/Views/PostView.swift
@@ -46,7 +46,6 @@ class PostView: UIView, UIGestureRecognizerDelegate {
     var type: ViewType = .Feed
 	var songStatus: SavedSongStatus = .NotSaved
 	var delegate: PostViewDelegate?
-	var playerController: PlayerTableViewController?
     private var updateTimer: NSTimer?
     private var notificationHandler: AnyObject?
     
@@ -343,8 +342,9 @@ class PostView: UIView, UIGestureRecognizerDelegate {
 				delegate?.didTapImageForPostView?(self)
 			} else {
 				post.player.togglePlaying()
-				print(playerController)
-				playerController?.updatePlayInfo()
+				//print(playerController)
+				//playerController?.updatePlayInfo()
+				(delegate as! PlayerTableViewController).updatePlayInfo()
 			}
 		}
 	}


### PR DESCRIPTION
Originally for issue 17 but also fixes command center functionality for any PlayerTableViewController. In order for pinning to work, the logic for song playing needed to be moved to PostView (where favoriting + adding is also implemented, so everything is consistent), and then there needed to be communication between the PlayerTableViewController and PostView, so that currentlyPlayingIndexPath + currentlyPlayingPost could be updated appropriately. I took advantage of the fact that all PlayerTableViewController subclasses (LikedTableViewController, FeedViewController, PostHistoryController) were also PostViewDelegates, so instead of creating another delegate for PostViews, I reference it through the existing PostviewDelegate, and just made all PlayerTableViewControllers PostviewDelegates. For the Command Center, the targets were accumulating if you would move from FeedView to LikedView for example which would make it buggy, so I have a function clearing all previous targets as soon as you click on a song in the LikedView. 
