### PR TITLE
Remove empty view for feed after posting

### DIFF
--- a/IceFishing/Controllers/FeedViewController.swift
+++ b/IceFishing/Controllers/FeedViewController.swift
@@ -171,7 +171,7 @@ class FeedViewController: PlayerTableViewController, SongSearchDelegate, PostVie
 	func didSelectSong(song: Song) {
 		posts.insert(Post(song: song, user: User.currentUser, date: NSDate()), atIndex: 0)
 		API.sharedAPI.updatePost(User.currentUser.id, song: song) { [weak self] _ in
-			self?.tableView.reloadData()
+			self?.refreshFeed()
 		}
 	}
 	


### PR DESCRIPTION
Changed response to a song being posted so that feed is refreshed instead of the table view. Now the appropriate table view background will be set. Addresses #28. Also, you can only see this error if your feed is empty, so someone who hasn't posted a song yet may want to test my branch.
