### PR TITLE
Force clear image cache on login

### DIFF
--- a/Tempo/AppDelegate.swift
+++ b/Tempo/AppDelegate.swift
@@ -10,6 +10,7 @@ import UIKit
 import FBSDKCoreKit
 import FBSDKLoginKit
 import SWRevealViewController
+import Haneke
 
 extension NSURL {
 	func getQueryItemValueForKey(key: String) -> AnyObject? {
@@ -179,6 +180,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, SWRevealViewControllerDel
 				self.fbSessionStateChanged(error)
 			}
 		}
+		Shared.imageCache.removeAll()
 	}
 	
 	// Facebook Session


### PR DESCRIPTION
Deals with https://github.com/cuappdev/tempo/issues/89

The problem was that once the profile picture is loaded in to Haneke's imageCache, it literally never gets evicted, because the cache is LRU and the profile picture is used very often.

After thinking about this for a long time...in my opinion, this is the best solution to the problem. Alternatives were: 
1) Evict only the Facebook profile image, but I tried it and apparently the remove feature in Haneke is bugged.......
we would have to alter the UI to have some dedicated "Update Images" button, which seems like a little too much. 
2) We have pull refresh clear the images, but that seems too often and drastic in my opinion. A lot of useful images would get removed as well.
3) Don't use the cache for the profile picture, which defeats the purpose of the cache (since it prevents repeated loading of the same picture)

Clearing the cache on login makes sense because:
a) Doesn't happen too often (and profile picture changing shouldn't happen often too)
b) Assuming you are logging into somebody else's account on your phone, you want to clear the cache anyways
c) IMO it's natural to try to re-log in when trying to update something (I've done it when trying to update Spotify prof pic, etc.)
