### PR TITLE
Closing revealGesture works and move revealGesture handling to AppDel…

### DIFF
--- a/Tempo/AppDelegate.swift
+++ b/Tempo/AppDelegate.swift
@@ -35,6 +35,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, SWRevealViewControllerDel
 	let likedVC = LikedTableViewController()
 	let spotifyVC = SpotifyViewController(nibName: "SpotifyViewController", bundle: nil)
 	let aboutVC = AboutViewController(nibName: "AboutViewController", bundle: nil)
+	let transparentView = UIView(frame: CGRect(x: 0, y: 0, width: UIScreen.mainScreen().bounds.width, height: UIScreen.mainScreen().bounds.height))
 	let navigationController = PlayerNavigationController()
 	
 	//slack info
@@ -244,10 +245,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate, SWRevealViewControllerDel
 	func revealController(revealController: SWRevealViewController!, willMoveToPosition position: FrontViewPosition) {
 		UIApplication.sharedApplication().sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, forEvent: nil)
 		if position == .Left {
-			revealController.frontViewController.view.userInteractionEnabled = true
+			if let _ = transparentView.superview {
+				transparentView.removeGestureRecognizer(revealVC.panGestureRecognizer())
+				transparentView.removeFromSuperview()
+			}
+			revealController.frontViewController.view.addGestureRecognizer(revealVC.panGestureRecognizer())
 			revealController.frontViewController.revealViewController().tapGestureRecognizer()
 		} else {
-			revealController.frontViewController.view.userInteractionEnabled = false
+			revealController.frontViewController.view.removeGestureRecognizer(revealVC.panGestureRecognizer())
+			transparentView.addGestureRecognizer(revealVC.panGestureRecognizer())
+			navigationController.view.addSubview(transparentView)
 		}
 		//Notify any hamburger menus that the menu is being toggled
 		NSNotificationCenter.defaultCenter().postNotificationName(RevealControllerToggledNotificaiton, object: revealController)

--- a/Tempo/Controllers/AboutViewController.swift
+++ b/Tempo/Controllers/AboutViewController.swift
@@ -25,7 +25,6 @@ class AboutViewController: UIViewController {
 		title = "About"
 		
 		addHamburgerMenu()
-		addRevealGesture()
 		
 		aboutLabel.numberOfLines = 0;
 		teamLabel.numberOfLines = 0;

--- a/Tempo/Controllers/PlayerTableViewController.swift
+++ b/Tempo/Controllers/PlayerTableViewController.swift
@@ -88,14 +88,7 @@ class PlayerTableViewController: UIViewController, UITableViewDelegate, UITableV
 	override func viewDidAppear(animated: Bool) {
 		super.viewDidAppear(animated)
 		
-		addRevealGesture()
 		justOpened = true
-	}
-	
-	override func viewDidDisappear(animated: Bool) {
-		super.viewDidDisappear(animated)
-		
-		removeRevealGesture()
 	}
 	
     // MARK: - Table view data source

--- a/Tempo/Controllers/SearchViewController.swift
+++ b/Tempo/Controllers/SearchViewController.swift
@@ -59,7 +59,6 @@ class SearchViewController: UIViewController, UITableViewDataSource, UITableView
 	override func viewDidAppear(animated: Bool) {
 		super.viewDidAppear(animated)
 		
-		addRevealGesture()
 		view.layoutIfNeeded()
 		tableView.tableFooterView = UIView()
 		
@@ -86,12 +85,6 @@ class SearchViewController: UIViewController, UITableViewDataSource, UITableView
 			searchBar.userInteractionEnabled = true
 			searchBar.becomeFirstResponder()
 		}
-	}
-	
-	override func viewDidDisappear(animated: Bool) {
-		super.viewDidDisappear(animated)
-		
-		removeRevealGesture()
 	}
 	
 	override func viewDidLayoutSubviews() {

--- a/Tempo/Controllers/SpotifyViewController.swift
+++ b/Tempo/Controllers/SpotifyViewController.swift
@@ -23,7 +23,6 @@ class SpotifyViewController: UIViewController {
 		
 		title = "Spotify"
 		addHamburgerMenu()
-		addRevealGesture()
 		updateSpotifyState()
 		
         profilePicture.layer.cornerRadius = profilePicture.frame.size.width/2
@@ -38,12 +37,6 @@ class SpotifyViewController: UIViewController {
 			button.layer.cornerRadius = 5.0
 			button.layer.masksToBounds = true
 		}
-	}
-	
-	override func viewDidDisappear(animated: Bool) {
-		super.viewDidDisappear(animated)
-		
-		removeRevealGesture()
 	}
 	
 	// Can be called after successful login to Spotify SDK

--- a/Tempo/Profile/ProfileViewController.swift
+++ b/Tempo/Profile/ProfileViewController.swift
@@ -76,19 +76,7 @@ class ProfileViewController: UIViewController, UICollectionViewDelegate, UIColle
 		usernameLabel.hidden = notConnected(false)
 		followButton.hidden = notConnected(false)
 	}
-	
-	override func viewDidAppear(animated: Bool) {
-		super.viewDidAppear(animated)
-		
-		addRevealGesture()
-	}
-	
-	override func viewDidDisappear(animated: Bool) {
-		super.viewDidDisappear(animated)
-		
-		removeRevealGesture()
-	}
-	
+
 	func setupUserUI() {
 		API.sharedAPI.fetchPosts(user.id) { post in
 			self.posts = post

--- a/Tempo/Profile/UsersViewController.swift
+++ b/Tempo/Profile/UsersViewController.swift
@@ -14,8 +14,9 @@ enum DisplayType: String {
 	case Users = "Users"
 }
 
-class UsersViewController: UITableViewController, UISearchResultsUpdating, UISearchControllerDelegate, UISearchBarDelegate, FollowUserDelegate {
+class UsersViewController: UIViewController, UITableViewDelegate, UITableViewDataSource, UISearchResultsUpdating, UISearchControllerDelegate, UISearchBarDelegate, FollowUserDelegate {
 
+	var tableView: UITableView!
 	var user: User = User.currentUser
 	var displayType: DisplayType = .Users
 	private var users: [User] = []
@@ -29,12 +30,17 @@ class UsersViewController: UITableViewController, UISearchResultsUpdating, UISea
     override func viewDidLoad() {
         super.viewDidLoad()
 		
+		tableView = UITableView(frame: CGRectMake(0, 0, UIScreen.mainScreen().bounds.width, UIScreen.mainScreen().bounds.height - playerCellHeight), style: .Plain)
+		tableView.delegate = self
+		tableView.dataSource = self
+		
 		extendedLayoutIncludesOpaqueBars = true
 		definesPresentationContext = true
 		view.backgroundColor = UIColor.tempoDarkGray
 		tableView.rowHeight = 80
 		tableView.showsVerticalScrollIndicator = false
 		tableView.registerNib(UINib(nibName: "FollowTableViewCell", bundle: nil), forCellReuseIdentifier: "FollowCell")
+		self.view.addSubview(tableView)
 		
 		// Set up search bar
 		searchController = UISearchController(searchResultsController: nil)
@@ -111,19 +117,14 @@ class UsersViewController: UITableViewController, UISearchResultsUpdating, UISea
 	}
 	
 	override func viewDidAppear(animated: Bool) {
-		addRevealGesture()
 		if !searchController.active && displayType == .Users {
 			populateSuggestions()
 		}
 	}
 	
-	override func viewDidDisappear(animated: Bool) {
-		removeRevealGesture()
-	}
-	
     // MARK: Table View Methods
 	
-    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+	func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
 		if displayType == .Users {
 			return searchController.active ? users.count : suggestedUsers.count
 		} else {
@@ -131,7 +132,7 @@ class UsersViewController: UITableViewController, UISearchResultsUpdating, UISea
 		}
     }
     
-    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+    func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCellWithIdentifier("FollowCell", forIndexPath: indexPath) as! FollowTableViewCell
 		var user: User
 		if displayType == .Users {
@@ -156,11 +157,11 @@ class UsersViewController: UITableViewController, UISearchResultsUpdating, UISea
         return cell
     }
     
-    override func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
+    func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
         return 80
     }
     
-    override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+    func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         let selectedCell: UITableViewCell = tableView.cellForRowAtIndexPath(indexPath)!
         selectedCell.contentView.backgroundColor = UIColor.tempoLightGray
 		
@@ -178,7 +179,7 @@ class UsersViewController: UITableViewController, UISearchResultsUpdating, UISea
         navigationController?.pushViewController(profileVC, animated: true)
     }
 	
-	override func scrollViewDidScroll(scrollView: UIScrollView) {
+	func scrollViewDidScroll(scrollView: UIScrollView) {
 		if !searchController.active {
 			let contentOffset = scrollView.contentOffset.y
 			let maximumOffset = scrollView.contentSize.height - scrollView.frame.size.height;

--- a/Tempo/Utilities/Tools/UIViewController+Utilities.swift
+++ b/Tempo/Utilities/Tools/UIViewController+Utilities.swift
@@ -23,18 +23,6 @@ extension UIViewController {
 		revealViewController().revealToggle(hamburgerIconView)
 	}
 	
-	func addRevealGesture() {
-		if revealViewController() != nil {
-			view.addGestureRecognizer(revealViewController().panGestureRecognizer())
-		}
-	}
-	
-	func removeRevealGesture() {
-		if revealViewController() != nil {
-			view.removeGestureRecognizer(revealViewController().panGestureRecognizer())
-		}
-	}
-	
 	// If not connected to internet return true and display banner if animated
 	func notConnected(animated: Bool) -> Bool {
 		if !API.sharedAPI.isConnected {


### PR DESCRIPTION
…egate, fix some playerCell spacing bug in UsersViewController

Done with a transparent UIView that is placed whenever the the revealController will move right. When it's moved left, the UIView is removed.

Gets rid of all the redundant addRevealGesture() and removeRevealGesture() calls throughout the app too.

Leaves space for playerCell in the UsersViewController

#112 