### PR TITLE
Bug fix for liking a song before playing anything

### DIFF
--- a/Tempo/Controllers/FeedViewController.swift
+++ b/Tempo/Controllers/FeedViewController.swift
@@ -274,13 +274,15 @@ class FeedViewController: PlayerTableViewController, SongSearchDelegate {
 	}
 	
 	func didToggleLike() {
-		if let cell = tableView.cellForRow(at: currentlyPlayingIndexPath!) as? FeedTableViewCell {
-			cell.postView.updateLikedStatus()
-			playerNav.playerCell.updateLikeButton()
-			playerNav.expandedCell.updateLikeButton()
+		//if there is a currentlyPlayingIndexPath, need to sync liked status of playerCells and post
+		if let currentlyPlayingIndexPath = currentlyPlayingIndexPath {
+			if let cell = tableView.cellForRow(at: currentlyPlayingIndexPath) as? FeedTableViewCell {
+				cell.postView.updateLikedStatus()
+				playerNav.playerCell.updateLikeButton()
+				playerNav.expandedCell.updateLikeButton()
+			}
 		}
 	}
-
 }
 
 @available(iOS 9.0, *)


### PR DESCRIPTION
#125 

But I think wrapping everything in an `if let currentlyPlayingIndexPath = currentlyPlayingIndexPath` is a simpler solution, since if there is no currentlyPlayingIndexPath, then there is no need for this method to actually do anything, since that means the playerCell doesn't have any song anyways.