### PR TITLE
Fix bug for bringing to settings page if trying to add song w/o login…

### DIFF
--- a/Tempo/Controllers/FeedViewController.swift
+++ b/Tempo/Controllers/FeedViewController.swift
@@ -182,7 +182,7 @@ class FeedViewController: PlayerTableViewController, SongSearchDelegate, FeedFol
 		//animate currently playing song
 		if let playerCellPost = self.playerNav.playerCell.post {
 			for row in 0 ..< posts.count {
-				if posts[row].song.spotifyID == playerCellPost.song.spotifyID {
+				if posts[row].song.equals(other: playerCellPost.song) {
 					posts[row] = playerCellPost
 					let indexPath = IndexPath(row: row, section: 0)
 					if let cell = tableView.cellForRow(at: indexPath) as? FeedTableViewCell {

--- a/Tempo/Controllers/SettingsViewController.swift
+++ b/Tempo/Controllers/SettingsViewController.swift
@@ -26,6 +26,7 @@ class SettingsViewController: UIViewController {
 	
 	static let registeredForRemotePushNotificationsKey = "SettingsViewController.registeredForRemotePushNotificationsKey"
 	static let presentedAlertForRemotePushNotificationsKey = "SettingsViewController.presentedAlertForRemotePushNotificationsKey"
+	var shouldAddHamburger = true
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
@@ -40,6 +41,10 @@ class SettingsViewController: UIViewController {
 	override func viewWillAppear(_ animated: Bool) {
 		updateSpotifyState()
 		toggleNotifications.setOn(User.currentUser.remotePushNotificationsEnabled, animated: false)
+		
+		if shouldAddHamburger {
+			addHamburgerMenu()
+		}
 	}
 	
 	override func viewDidAppear(_ animated: Bool) {
@@ -47,8 +52,11 @@ class SettingsViewController: UIViewController {
 		
 		title = "Settings"
 		view.backgroundColor = .readCellColor
-		
-		addHamburgerMenu()
+	}
+	
+	override func viewWillDisappear(_ animated: Bool) {
+		//add HamburgerMenu by default, unless shouldAddHamburger is explicitly changed
+		shouldAddHamburger = true
 	}
 	
 	// Can be called after successful login to Spotify SDK
@@ -146,7 +154,7 @@ class SettingsViewController: UIViewController {
 	
 	@IBAction func logOutSpotify(_ sender: UIButton) {
 		SpotifyController.sharedController.closeCurrentSpotifySession()
-		
+		User.currentUser.currentSpotifyUser = nil
 		updateSpotifyState()
 	}
 }

--- a/Tempo/Views/ParentPlayerCellView.swift
+++ b/Tempo/Views/ParentPlayerCellView.swift
@@ -48,32 +48,34 @@ class ParentPlayerCellView: UIView {
 	
 	//Switches saved to notSaved, or notSaved to saved, and calls updateAddButton()
 	func toggleAddButton() {
-		SpotifyController.sharedController.spotifyIsAvailable { success in
-			if success && songStatus == .notSaved {
-				SpotifyController.sharedController.saveSpotifyTrack(post!) { success in
-					if success {
-						self.playerNav?.playerCell.updateAddButton()
-						self.playerNav?.expandedCell.updateAddButton()
-						self.delegate?.didToggleAdd?()
+		if let _ = User.currentUser.currentSpotifyUser {
+			SpotifyController.sharedController.spotifyIsAvailable { success in
+				if success && songStatus == .notSaved {
+					SpotifyController.sharedController.saveSpotifyTrack(post!) { success in
+						if success {
+							self.playerNav?.playerCell.updateAddButton()
+							self.playerNav?.expandedCell.updateAddButton()
+							self.delegate?.didToggleAdd?()
+						}
+					}
+				} else if success && songStatus == .saved {
+					SpotifyController.sharedController.removeSavedSpotifyTrack(post!) { success in
+						if success {
+							self.playerNav?.playerCell.updateAddButton()
+							self.playerNav?.expandedCell.updateAddButton()
+							self.delegate?.didToggleAdd?()
+						}
 					}
 				}
-			} else if success && songStatus == .saved {
-				SpotifyController.sharedController.removeSavedSpotifyTrack(post!) { success in
-					if success {
-						self.playerNav?.playerCell.updateAddButton()
-						self.playerNav?.expandedCell.updateAddButton()
-						self.delegate?.didToggleAdd?()
-					}
-				}
-			} else {
-				//bring them to settingsVC
-				let appDelegate = UIApplication.shared.delegate as! AppDelegate
-				let playerNav = appDelegate.navigationController
-				let revealVC = appDelegate.revealVC
-				let settingsVC = appDelegate.settingsVC
-				playerNav.setViewControllers([settingsVC], animated: true)
-				revealVC.setFrontViewPosition(.left, animated: true)
 			}
+		} else {
+			//bring them to settingsVC
+			let appDelegate = UIApplication.shared.delegate as! AppDelegate
+			let playerNav = appDelegate.navigationController
+			let settingsVC = appDelegate.settingsVC
+			settingsVC.shouldAddHamburger = false
+			settingsVC.navigationItem.leftBarButtonItem = nil //clear existing hamburgerMenu, if there
+			playerNav.pushViewController(settingsVC, animated: true)
 		}
 	}
 	


### PR DESCRIPTION
… to Spotify

#191 

This was implemented a while ago, but I misunderstood what `SpotifyIsAvailable` was doing... my bad.

It doesn't show a popup, but it pushes the SettingsVC on top, to imply that they should log in. Made it so clicking back button returns them to their previous VC easily