### PR TITLE
Music player now closes when user opens Post a track

### DIFF
--- a/Tempo/Controllers/FeedViewController.swift
+++ b/Tempo/Controllers/FeedViewController.swift
@@ -282,6 +282,7 @@ class FeedViewController: PlayerTableViewController, SongSearchDelegate, FeedFol
 		searchTableViewController.navigationItem.rightBarButtonItem = navigationItem.rightBarButtonItem
 		searchTableViewController.navigationItem.leftBarButtonItem = navigationItem.leftBarButtonItem
 		searchTableViewController.selfPostIds = posts.filter({ $0.user.name == User.currentUser.name }).map({ $0.song.spotifyID })
+		playerNav.animateExpandedCell(isExpanding: false)
 		navigationController?.pushViewController(searchTableViewController, animated: false)
 	}
 	


### PR DESCRIPTION
Minor tweak now closes music player if expanded when users clicks on plus button to search for a track to post.