### PR TITLE
Track saving should support multiple accounts, updates saved tracks o…

### DIFF
--- a/Tempo/AppDelegate.swift
+++ b/Tempo/AppDelegate.swift
@@ -82,7 +82,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, SWRevealViewControllerDel
 		
 		if SPTAuth.defaultInstance().session != nil && SPTAuth.defaultInstance().session.isValid() {
 			SpotifyController.sharedController.setSpotifyUser(SPTAuth.defaultInstance().session.accessToken, completion: nil)
-			User.currentUser.currentSpotifyUser?.savedTracks = UserDefaults.standard.dictionary(forKey: "savedTracks") as [String : AnyObject]? ?? [:]
+			User.currentUser.currentSpotifyUser?.savedTracks = UserDefaults.standard.dictionary(forKey: User.currentUser.currentSpotifyUser!.savedTracksKey) as [String : AnyObject]? ?? [:]
 		}
 
 		window = UIWindow(frame: UIScreen.main.bounds)

--- a/Tempo/Controllers/SettingsViewController.swift
+++ b/Tempo/Controllers/SettingsViewController.swift
@@ -78,6 +78,8 @@ class SettingsViewController: UIViewController {
 		} else {
 			loggedInToSpotify(false)
 		}
+		let playerNav = navigationController as! PlayerNavigationController
+		playerNav.updateAddButton()
 	}
 	
 	func loggedInToSpotify(_ loggedIn: Bool) {

--- a/Tempo/Controllers/SpotifyController.swift
+++ b/Tempo/Controllers/SpotifyController.swift
@@ -89,9 +89,9 @@ class SpotifyController {
 				SPTYourMusic.saveTracks([data!], forUserWithAccessToken: SPTAuth.defaultInstance().session.accessToken) { error, result in
 					if error != nil {
 						completionHandler(false)
-					} else {
-						User.currentUser.currentSpotifyUser?.savedTracks[track.song.spotifyID] = true as AnyObject?
-						UserDefaults.standard.setValue(User.currentUser.currentSpotifyUser?.savedTracks, forKey: "savedTracks")
+					} else if let currentSpotifyUser = User.currentUser.currentSpotifyUser {
+						currentSpotifyUser.savedTracks[track.song.spotifyID] = true as AnyObject?
+						UserDefaults.standard.setValue(User.currentUser.currentSpotifyUser?.savedTracks, forKey: currentSpotifyUser.savedTracksKey)
 						completionHandler(true)
 					}
 				}

--- a/Tempo/Models/User.swift
+++ b/Tempo/Models/User.swift
@@ -127,21 +127,26 @@ class CurrentSpotifyUser: NSObject, NSCoding {
         return URL(string: imageURLString)!
     }
 	var savedTracks = [String : AnyObject]()
-    
+	
+	var savedTracksKey: String {
+		return "savedTracks-\(username)"
+	}
+	
     init(json: JSON) {
         name = json["display_name"].stringValue
         username = json["id"].stringValue
         let images = json["images"].arrayValue
 		imageURLString = images.isEmpty ? "" : images[0]["url"].stringValue
         let externalURLs = json["external_urls"].dictionaryValue
-		spotifyUserURLString = externalURLs["spotify"]!.stringValue 
+		spotifyUserURLString = externalURLs["spotify"]!.stringValue
 		super.init()
+		savedTracks = UserDefaults.standard.dictionary(forKey: savedTracksKey) as [String : AnyObject]? ?? [:]
     }
 	
     override var description: String {
         return "Name: \(name)| Username: \(username)"
     }
-    
+	
     // Extend NSCoding
     // MARK: - NSCoding
     


### PR DESCRIPTION
…n logging in and out of Spotify

#190 

- Use username for the UserDefaults key, in case one phone is used for multiple Spotify accounts
- Fix bug where on logging into Spotify, the savedTracks aren't being loaded from the UserDefaults
- Fix bug where on logging in/out of Spotify, the playerCells add buttons are not updated immediately
