### PR TITLE
Keivan/music exit

### DIFF
--- a/Tempo.xcodeproj/project.pbxproj
+++ b/Tempo.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		6038B1801D80EDAF0083940D /* FeedTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6038B17F1D80EDAF0083940D /* FeedTableViewCell.xib */; };
 		60419BED1DE24AE800CAB9BD /* SettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 60419BEC1DE24AE800CAB9BD /* SettingsViewController.xib */; };
 		6067F0821BFD4F7E004059A0 /* FollowSuggestionTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6067F0801BFD4F7E004059A0 /* FollowSuggestionTableViewController.swift */; };
+		60728FBA1E6369150097C1AC /* PostTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60728FB91E6369150097C1AC /* PostTableViewCell.swift */; };
 		6084F6C51BE700B00048EFE3 /* PlayerTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6084F6C41BE700B00048EFE3 /* PlayerTableViewController.swift */; };
 		6092CBD91C021C5E008836AE /* FollowSuggestionsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6092CBD71C021C5E008836AE /* FollowSuggestionsTableViewCell.swift */; };
 		6092CBDA1C021C5E008836AE /* FollowSuggestionsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6092CBD81C021C5E008836AE /* FollowSuggestionsTableViewCell.xib */; };
@@ -139,6 +140,7 @@
 		6038B17F1D80EDAF0083940D /* FeedTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = FeedTableViewCell.xib; path = ../Profile/FeedTableViewCell.xib; sourceTree = "<group>"; };
 		60419BEC1DE24AE800CAB9BD /* SettingsViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SettingsViewController.xib; sourceTree = "<group>"; };
 		6067F0801BFD4F7E004059A0 /* FollowSuggestionTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FollowSuggestionTableViewController.swift; sourceTree = "<group>"; };
+		60728FB91E6369150097C1AC /* PostTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostTableViewCell.swift; sourceTree = "<group>"; };
 		6084F6C41BE700B00048EFE3 /* PlayerTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlayerTableViewController.swift; sourceTree = "<group>"; };
 		6092CBD71C021C5E008836AE /* FollowSuggestionsTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FollowSuggestionsTableViewCell.swift; sourceTree = "<group>"; };
 		6092CBD81C021C5E008836AE /* FollowSuggestionsTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = FollowSuggestionsTableViewCell.xib; sourceTree = "<group>"; };
@@ -338,6 +340,7 @@
 				D160ADFE1BE67406003B0E1A /* PlaylistTableViewCell.xib */,
 				0271C9451D9582410037F6AD /* PostHistoryHeaderSectionCell.swift */,
 				0271C9461D9582410037F6AD /* PostHistoryHeaderSectionCell.xib */,
+				60728FB91E6369150097C1AC /* PostTableViewCell.swift */,
 			);
 			name = Cells;
 			sourceTree = "<group>";
@@ -624,6 +627,7 @@
 				1DFBFB541B784634001DD6AC /* SongSearchTableViewCell.swift in Sources */,
 				60256C1A1BC1BFA900B52FDD /* SavedSongView.swift in Sources */,
 				1D72D9BB1AACC4C0007822B0 /* AppDelegate.swift in Sources */,
+				60728FBA1E6369150097C1AC /* PostTableViewCell.swift in Sources */,
 				6038B17A1D80EBEA0083940D /* UIViewController+Utilities.swift in Sources */,
 				FAB564731AF6A8C9001059DF /* LikedTableViewController.swift in Sources */,
 				1DD875FC1B6E27DD0041C45B /* NSDateFormatter+Shared.swift in Sources */,

--- a/Tempo.xcodeproj/project.pbxproj
+++ b/Tempo.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		95D1E77E1CE20BED00E1EF0F /* HamburgerIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D1E77D1CE20BED00E1EF0F /* HamburgerIconView.swift */; };
 		BA24C57D1AF866630066C2ED /* SearchPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA24C57C1AF866630066C2ED /* SearchPostView.swift */; };
 		C7B1984E1DD67D6800EAB8EA /* SpotifyLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B1984D1DD67D6800EAB8EA /* SpotifyLoginViewController.swift */; };
+		C7EEF4C51E5E4EDF00C6EF94 /* FeedPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7EEF4C41E5E4EDF00C6EF94 /* FeedPostView.swift */; };
 		D102A9C71AE889D600C66385 /* SideBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D102A9C51AE889D600C66385 /* SideBarViewController.swift */; };
 		D102A9D11AE88CB400C66385 /* SideBarTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D102A9CF1AE88CB400C66385 /* SideBarTableViewCell.swift */; };
 		D11740001AF8574400302FFD /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1173FFF1AF8574400302FFD /* ProfileViewController.swift */; };
@@ -168,6 +169,7 @@
 		BA257E271ABA3FE200D939B0 /* Tempo-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Tempo-Bridging-Header.h"; sourceTree = "<group>"; };
 		C0CF7B971AE425450083606C /* API.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
 		C7B1984D1DD67D6800EAB8EA /* SpotifyLoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpotifyLoginViewController.swift; sourceTree = "<group>"; };
+		C7EEF4C41E5E4EDF00C6EF94 /* FeedPostView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedPostView.swift; sourceTree = "<group>"; };
 		D102A9C51AE889D600C66385 /* SideBarViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SideBarViewController.swift; sourceTree = "<group>"; };
 		D102A9CF1AE88CB400C66385 /* SideBarTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SideBarTableViewCell.swift; path = ../Profile/SideBarTableViewCell.swift; sourceTree = "<group>"; };
 		D1173FFF1AF8574400302FFD /* ProfileViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
@@ -256,6 +258,7 @@
 				60AEF7691DBD38AD00C68AAF /* ProgressView.swift */,
 				95D1E77D1CE20BED00E1EF0F /* HamburgerIconView.swift */,
 				FA1E1A7D1ADB0818007C823C /* PostView.swift */,
+				C7EEF4C41E5E4EDF00C6EF94 /* FeedPostView.swift */,
 				0276B1FB1DDFBAD800B512E9 /* LikedPostView.swift */,
 				BA24C57C1AF866630066C2ED /* SearchPostView.swift */,
 				60256C191BC1BFA900B52FDD /* SavedSongView.swift */,
@@ -637,6 +640,7 @@
 				952E7EE21DEA8E6E006C6131 /* FacebookLoginViewController.swift in Sources */,
 				02803D4F1DC18524001D8F01 /* ExpandedPlayerView.swift in Sources */,
 				FA674C071AF9105E00C14463 /* ADRefreshControl.swift in Sources */,
+				C7EEF4C51E5E4EDF00C6EF94 /* FeedPostView.swift in Sources */,
 				D19E42121DF6262000D09F18 /* ProfileHeaderView.swift in Sources */,
 				D102A9C71AE889D600C66385 /* SideBarViewController.swift in Sources */,
 				6DA5FE4D1AED72F800E795DD /* UIColor+Shared.swift in Sources */,

--- a/Tempo/AppDelegate.swift
+++ b/Tempo/AppDelegate.swift
@@ -219,6 +219,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate, SWRevealViewControllerDel
 	func applicationDidEnterBackground(_ application: UIApplication) {
 		if !UserDefaults.standard.bool(forKey: "music_on_off"){
 			navigationController.togglePause()
+			let center = MPNowPlayingInfoCenter.default()
+			UIApplication.shared.endReceivingRemoteControlEvents()
+			center.nowPlayingInfo = nil
+		}
+	}
+	
+	func applicationWillEnterForeground(_ application: UIApplication) {
+		if let _ = navigationController.currentPost {
+			navigationController.postView?.updatePlayingStatus()
 		}
 	}
 	

--- a/Tempo/AppDelegate.swift
+++ b/Tempo/AppDelegate.swift
@@ -216,6 +216,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, SWRevealViewControllerDel
 		return FBSDKApplicationDelegate.sharedInstance().application(application, open: url, sourceApplication: sourceApplication, annotation: annotation)
 	}
 	
+	func applicationDidEnterBackground(_ application: UIApplication) {
+		if !UserDefaults.standard.bool(forKey: "music_on_off"){
+			navigationController.togglePause()
+		}
+	}
+	
 	// MARK: - SWRevealDelegate
 	
 	func revealController(_ revealController: SWRevealViewController!, willMoveTo position: FrontViewPosition) {

--- a/Tempo/Controllers/FeedViewController.swift
+++ b/Tempo/Controllers/FeedViewController.swift
@@ -89,13 +89,7 @@ class FeedViewController: PlayerTableViewController, SongSearchDelegate, FeedFol
 		
 		//Animate appropriate cell if feed song is already playing
 		if let currentPost = playerNav.currentPost, playerNav.playingPostType == .feed {
-			let rowCount = tableView.numberOfRows(inSection: 0)
-			for row in 0 ..< rowCount {
-				if let thisCell = tableView.cellForRow(at: NSIndexPath(row: row, section: 0) as IndexPath) as? FeedTableViewCell, thisCell.postView.post == currentPost {
-					thisCell.postView.updatePlayingStatus()
-					break
-				}
-			}
+				thisCell.postView.updatePlayingStatus()
 		}
 	}
 	

--- a/Tempo/Controllers/LikedTableViewController.swift
+++ b/Tempo/Controllers/LikedTableViewController.swift
@@ -16,6 +16,7 @@ class LikedTableViewController: PlayerTableViewController {
 		title = "Liked"
 		extendedLayoutIncludesOpaqueBars = true
 		definesPresentationContext = true
+		playingPostType = .liked
 		
 		tableView.rowHeight = 91
 		tableView.backgroundColor = .readCellColor
@@ -48,12 +49,14 @@ class LikedTableViewController: PlayerTableViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
 		let cell = tableView.dequeueReusableCell(withIdentifier: "LikedCell", for: indexPath) as! LikedTableViewCell
 		let posts = searchController.isActive ? filteredPosts : self.posts
-		cell.postView?.albumArtworkImageView?.image = nil
+		cell.likedPostView?.albumArtworkImageView?.image = nil
 		cell.setupCell(spotifyAvailable: SpotifyController.sharedController.isSpotifyAvailable)
-		cell.postView?.post = posts[indexPath.row]
-		cell.postView?.postViewDelegate = self
-		cell.postView?.playerDelegate = self
-		cell.postView?.updatePlayingStatus()
+		cell.likedPostView?.post = posts[indexPath.row]
+		cell.likedPostView?.postViewDelegate = self
+		cell.likedPostView?.playerDelegate = self
+		cell.likedPostView?.updatePlayingStatus()
+		
+		transplantPlayerAndPostViewIfNeeded(cell: cell)
 		
 		return cell
     }
@@ -81,6 +84,7 @@ class LikedTableViewController: PlayerTableViewController {
 			
 			activityIndicatorView.stopAnimating()
 			activityIndicatorView.removeFromSuperview()
+			self.updatePlayingCells()
         }
     }
 	
@@ -88,10 +92,9 @@ class LikedTableViewController: PlayerTableViewController {
 		// if there is a currentlyPlayingIndexPath, need to sync add status of playerCells and post
 		if let currentlyPlayingIndexPath = currentlyPlayingIndexPath {
 			if let cell = tableView.cellForRow(at: currentlyPlayingIndexPath) as? LikedTableViewCell {
-				cell.postView?.updateAddStatus()
+				cell.likedPostView?.updateAddStatus()
 				playerNav.updateAddButton()
 			}
 		}
 	}
-
 }

--- a/Tempo/Controllers/PlayerTableViewController.swift
+++ b/Tempo/Controllers/PlayerTableViewController.swift
@@ -386,5 +386,6 @@ class PlayerTableViewController: UIViewController, UITableViewDelegate, UITableV
 		playerNav.currentPost = currentlyPlayingPost
 		playerNav.postsRef = posts
 		playerNav.postRefIndex = row
+		playerNav.postView = tableView.cellForRow(at: NSIndexPath(row: row, section: 1) as IndexPath).postView
 	}
 }

--- a/Tempo/Controllers/PlayerTableViewController.swift
+++ b/Tempo/Controllers/PlayerTableViewController.swift
@@ -47,43 +47,21 @@ class PlayerTableViewController: UIViewController, UITableViewDelegate, UITableV
 			if searchController.isActive {
 				array = filteredPosts
 			}
-            if let row = currentlyPlayingIndexPath?.row,
-				let delegate = playerNav.playerDelegate as? PlayerTableViewController,
-				let currentPost = playerNav.currentPost,
-				currentPost.equals(other: array[row]),
-				self == delegate {
+            if let row = currentlyPlayingIndexPath?.row, let currentPost = playerNav.currentPost, currentPost.equals(other: array[row]), playerNav.playingPostType == playingPostType {
                 didTogglePlaying(animate: true)
             } else {
-				//Deal with previous post that's being played
-                currentlyPlayingPost?.player.pause()
-				currentlyPlayingPost?.player.progress = 0
-				if let oldValue = oldValue {
-					if self is PostHistoryTableViewController {
-						let neoSelf = self as! PostHistoryTableViewController
-						if let cell = tableView.cellForRow(at: neoSelf.relativeIndexPath(row: oldValue.row) as IndexPath) as? FeedTableViewCell {
-							cell.postView.updatePlayingStatus()
-						}
-					} else if self is LikedTableViewController {
-						if let cell = tableView.cellForRow(at: oldValue) as? LikedTableViewCell {
-							cell.postView?.updatePlayingStatus()
-						}
-					} else {
-						if let cell = tableView.cellForRow(at: oldValue) as? FeedTableViewCell {
-							cell.postView.updatePlayingStatus()
-						}
-					}
+				var newCell: PostTableViewCell? = nil
+				if self is PostHistoryTableViewController {
+					let neoSelf = self as! PostHistoryTableViewController
+					let relativeIndexPath = neoSelf.relativeIndexPath(row: currentlyPlayingIndexPath!.row)
+					newCell = tableView.cellForRow(at: relativeIndexPath) as? PostTableViewCell
+				} else {
+					newCell = tableView.cellForRow(at: currentlyPlayingIndexPath!) as? PostTableViewCell
 				}
 				
 				//update post to new song
                 currentlyPlayingPost = array[currentlyPlayingIndexPath!.row]
-				if self is FeedViewController {
-					playingPostType = .feed
-				} else if self is LikedTableViewController {
-					playingPostType = .liked
-				} else {
-					playingPostType = .history
-				}
-				updatePlayerNavRefs(row: currentlyPlayingIndexPath!.row)
+				updatePlayerNavRefs(row: currentlyPlayingIndexPath!.row, postView: newCell!.postView!)
 				didTogglePlaying(animate: true)
             }
             tableView.selectRow(at: currentlyPlayingIndexPath, animated: false, scrollPosition: .none)
@@ -137,6 +115,11 @@ class PlayerTableViewController: UIViewController, UITableViewDelegate, UITableV
 		super.viewDidAppear(animated)
 		
 		justOpened = true
+		for cell in tableView.visibleCells {
+			if let cell = cell as? PostTableViewCell {
+				cell.postView?.updatePlayingStatus()
+			}
+		}
 	}
 	
     // MARK: - Table view data source
@@ -156,7 +139,6 @@ class PlayerTableViewController: UIViewController, UITableViewDelegate, UITableV
 	func preparePosts() {
 		posts.forEach({ (post) in
 			post.player.delegate = self
-//			post.player.prepareToPlay()
 		})
 	}
 	
@@ -359,33 +341,39 @@ class PlayerTableViewController: UIViewController, UITableViewDelegate, UITableV
 	}
 	
 	// Updates all views related to some player
+	// Function to iterate through all cells in a PlayerTableViewController
+	// to pinpoint which cell is being played and transplant PostView.
 	func updatePlayingCells() {
-		if let path = currentlyPlayingIndexPath {
-			if self is PostHistoryTableViewController {
-				let neoSelf = self as! PostHistoryTableViewController
-				if let cell = tableView.cellForRow(at: neoSelf.relativeIndexPath(row: path.row) as IndexPath) as? FeedTableViewCell {
-					cell.postView.updatePlayingStatus()
-				}
-			} else if self is LikedTableViewController {
-				if let cell = tableView.cellForRow(at: path) as? LikedTableViewCell {
-					cell.postView?.updatePlayingStatus()
-				}
-			} else {
-				if let cell = tableView.cellForRow(at: path) as? FeedTableViewCell {
-					cell.postView.updatePlayingStatus()
-				}
+		if let _ = playerNav.currentPost {
+			if playerNav.playingPostType == playingPostType {
+				// playerNav.postView always guaranteed to have most recent postView
+				playerNav.postView?.updatePlayingStatus()
 			}
-			
-			playerNav.updatePlayingStatus()
+		}
+		playerNav.updatePlayingStatus()
+	}
+	
+	// To maintain invariant of playerNav.postView always having 
+	// the most up-to-date postView
+	func transplantPlayerAndPostViewIfNeeded(cell: PostTableViewCell) {
+		// swap in the old player to preserve song progress
+		// swap out the playerNav postView for the new one
+		if let currentPost = playerNav.currentPost, let post = cell.postView?.post, post.equals(other: currentPost), let type = playerNav.playingPostType, type == playingPostType {
+			if cell.postView != playerNav.postView {
+				// need to transplant new postView in, swap players
+				cell.postView?.post?.player = currentPost.player
+				playerNav.postView = cell.postView
+			}
+			cell.postView?.updatePlayingStatus()
 		}
 	}
 	
-	func updatePlayerNavRefs(row: Int) {
+	func updatePlayerNavRefs(row: Int, postView: PostView) {
 		playerNav.updateDelegates(delegate: self)
 		playerNav.playingPostType = playingPostType
 		playerNav.currentPost = currentlyPlayingPost
 		playerNav.postsRef = posts
 		playerNav.postRefIndex = row
-		playerNav.postView = tableView.cellForRow(at: NSIndexPath(row: row, section: 1) as IndexPath).postView
+		playerNav.postView = postView
 	}
 }

--- a/Tempo/Controllers/PostHistoryTableViewController.swift
+++ b/Tempo/Controllers/PostHistoryTableViewController.swift
@@ -23,6 +23,7 @@ class PostHistoryTableViewController: PlayerTableViewController {
         navigationItem.title = "Post History"
 		extendedLayoutIncludesOpaqueBars = true
 		definesPresentationContext = true
+		playingPostType = .history
 		
 		// Fix color above search bar
 		let topView = UIView(frame: view.frame)
@@ -45,7 +46,7 @@ class PostHistoryTableViewController: PlayerTableViewController {
 		preparePosts()
 		tableView.tableHeaderView = notConnected(true) ? nil : searchController.searchBar
 	}
-    
+	
     override func viewDidAppear(_ animated: Bool) {
 		super.viewDidAppear(animated)
 		
@@ -106,13 +107,16 @@ class PostHistoryTableViewController: PlayerTableViewController {
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
 		let cell = tableView.dequeueReusableCell(withIdentifier: "FeedCell", for: indexPath) as! FeedTableViewCell
-		cell.postView.avatarImageView?.image = nil
-		cell.postView.type = .history
+		cell.feedPostView.avatarImageView?.image = nil
+		cell.feedPostView.type = .history
 		let posts = searchController.isActive ? filteredPosts : self.posts
-		cell.postView.post = posts[absoluteIndex(indexPath)]
-		cell.postView.postViewDelegate = self
-		cell.postView.playerDelegate = self
+		let post = posts[absoluteIndex(indexPath)]
+		cell.feedPostView?.post = post
+		cell.feedPostView?.postViewDelegate = self
+		cell.feedPostView?.playerDelegate = self
 		cell.setUpPostHistoryCell()
+		
+		transplantPlayerAndPostViewIfNeeded(cell: cell)
 		
 		return cell
     }
@@ -137,25 +141,14 @@ class PostHistoryTableViewController: PlayerTableViewController {
 	
     func tableView(_ tableView: UITableView, didSelectRowAtIndexPath indexPath: IndexPath) {
         let selectedCell = tableView.cellForRow(at: indexPath) as! FeedTableViewCell
-		selectedCell.postView.backgroundColor = UIColor.tempoLightGray
+		selectedCell.feedPostView.backgroundColor = UIColor.tempoLightGray
 		currentlyPlayingIndexPath = IndexPath(row: absoluteIndex(indexPath), section: 0)
     } 
-	
-	// Updates all views related to some player
-	override func updatePlayingCells() {
-		if let currentlyPlayingIndexPath = currentlyPlayingIndexPath {
-			if let cell = tableView.cellForRow(at: relativeIndexPath(row: currentlyPlayingIndexPath.row) as IndexPath) as? FeedTableViewCell {
-				cell.postView.updatePlayingStatus()
-			}
-			
-			playerNav.updatePlayingStatus()
-		}
-	}
 	
 	func didToggleLike() {
 		if let currentlyPlayingIndexPath = currentlyPlayingIndexPath {
 			if let cell = tableView.cellForRow(at: relativeIndexPath(row: currentlyPlayingIndexPath.row) as IndexPath) as? FeedTableViewCell {
-				cell.postView.updateLikedStatus()
+				cell.feedPostView.updateLikedStatus()
 			}
 			playerNav.updateLikeButton()
 		}

--- a/Tempo/Controllers/SettingsViewController.swift
+++ b/Tempo/Controllers/SettingsViewController.swift
@@ -23,6 +23,7 @@ class SettingsViewController: UIViewController {
 	@IBOutlet weak var toggleNotifications: UISwitch!
 	@IBOutlet weak var useLabel: UILabel!
 	@IBOutlet weak var logOutButtonHeight: NSLayoutConstraint!
+	@IBOutlet weak var toggleMusicOnExit: UISwitch!
 	
 	static let registeredForRemotePushNotificationsKey = "SettingsViewController.registeredForRemotePushNotificationsKey"
 	static let presentedAlertForRemotePushNotificationsKey = "SettingsViewController.presentedAlertForRemotePushNotificationsKey"
@@ -32,6 +33,7 @@ class SettingsViewController: UIViewController {
 		super.viewDidLoad()
 
 		toggleNotifications.onTintColor = .tempoRed
+		toggleMusicOnExit.onTintColor = .tempoRed
 		profilePicture.layer.cornerRadius = profilePicture.frame.width / 2.0
 		
 		updateSpotifyState()
@@ -41,6 +43,8 @@ class SettingsViewController: UIViewController {
 	override func viewWillAppear(_ animated: Bool) {
 		updateSpotifyState()
 		toggleNotifications.setOn(User.currentUser.remotePushNotificationsEnabled, animated: false)
+		toggleMusicOnExit.setOn(UserDefaults.standard.bool(forKey: "music_on_off"), animated: false)
+		print(UserDefaults.standard.bool(forKey: "music_on_off"))
 		
 		if shouldAddHamburger {
 			addHamburgerMenu()
@@ -118,7 +122,6 @@ class SettingsViewController: UIViewController {
 	}
 	
 	@IBAction func toggledNotifications(_ sender: UISwitch) {
-		
 		let appDelegate = UIApplication.shared.delegate as! AppDelegate
 		let didRegisterForPushNotifications = UserDefaults.standard.bool(forKey: SettingsViewController.registeredForRemotePushNotificationsKey)
 		let didPresentAlertForPushNotifications = UserDefaults.standard.bool(forKey: SettingsViewController.presentedAlertForRemotePushNotificationsKey)
@@ -146,8 +149,18 @@ class SettingsViewController: UIViewController {
 			if !success {
 				sender.setOn(!enabled, animated: true)
 			}
-			
 		})
+	}
+	
+	@IBAction func toggledMusicOnExit(_ sender: UISwitch) {
+		let enabled = UserDefaults.standard.bool(forKey: "music_on_off")
+		if enabled {
+			UserDefaults.standard.set(!enabled, forKey: "music_on_off")
+		} else {
+			UserDefaults.standard.set(!enabled, forKey: "music_on_off")
+		}
+		sender.setOn(UserDefaults.standard.bool(forKey: "music_on_off"), animated: true)
+		//add logic to appdelegate to meet user's desired settings
 	}
 	
 	@IBAction func goToSpotify(_ sender: UIButton) {

--- a/Tempo/Controllers/SettingsViewController.swift
+++ b/Tempo/Controllers/SettingsViewController.swift
@@ -44,7 +44,6 @@ class SettingsViewController: UIViewController {
 		updateSpotifyState()
 		toggleNotifications.setOn(User.currentUser.remotePushNotificationsEnabled, animated: false)
 		toggleMusicOnExit.setOn(UserDefaults.standard.bool(forKey: "music_on_off"), animated: false)
-		print(UserDefaults.standard.bool(forKey: "music_on_off"))
 		
 		if shouldAddHamburger {
 			addHamburgerMenu()
@@ -154,11 +153,7 @@ class SettingsViewController: UIViewController {
 	
 	@IBAction func toggledMusicOnExit(_ sender: UISwitch) {
 		let enabled = UserDefaults.standard.bool(forKey: "music_on_off")
-		if enabled {
-			UserDefaults.standard.set(!enabled, forKey: "music_on_off")
-		} else {
-			UserDefaults.standard.set(!enabled, forKey: "music_on_off")
-		}
+		UserDefaults.standard.set(!enabled, forKey: "music_on_off")
 		sender.setOn(UserDefaults.standard.bool(forKey: "music_on_off"), animated: true)
 		//add logic to appdelegate to meet user's desired settings
 	}

--- a/Tempo/Controllers/SettingsViewController.xib
+++ b/Tempo/Controllers/SettingsViewController.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16C68" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -25,6 +25,7 @@
                 <outlet property="loginToSpotifyButton" destination="hCy-rO-jND" id="3hd-qg-5EL"/>
                 <outlet property="nameLabel" destination="eNa-sr-3In" id="Nzo-qt-Jra"/>
                 <outlet property="profilePicture" destination="3LL-O1-glU" id="Aeg-b6-P5B"/>
+                <outlet property="toggleMusicOnExit" destination="vby-YR-amp" id="ifg-3P-DIy"/>
                 <outlet property="toggleNotifications" destination="TyH-kz-APS" id="bzt-S8-6MT"/>
                 <outlet property="useLabel" destination="eD4-5d-DJ7" id="h5s-Qr-gRp"/>
                 <outlet property="usernameLabel" destination="pdg-bw-3Aj" id="ahV-Co-YY1"/>
@@ -36,20 +37,20 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NOTIFICATIONS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PTm-Qt-aaa">
-                    <rect key="frame" x="22" y="303" width="106.5" height="19.5"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="OPTIONS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PTm-Qt-aaa">
+                    <rect key="frame" x="22" y="277" width="62.5" height="20"/>
                     <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="14"/>
                     <color key="textColor" red="0.38823529411764707" green="0.38823529411764707" blue="0.38823529411764707" alpha="1" colorSpace="calibratedRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SPOTIFY" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6rq-4p-ZgW">
-                    <rect key="frame" x="22" y="30" width="51.5" height="18"/>
+                    <rect key="frame" x="22" y="30" width="52" height="18"/>
                     <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="13"/>
                     <color key="textColor" red="0.38823529410000002" green="0.38823529410000002" blue="0.38823529410000002" alpha="1" colorSpace="calibratedRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mPq-C5-plJ">
-                    <rect key="frame" x="0.0" y="203" width="375" height="50"/>
+                    <rect key="frame" x="0.0" y="202" width="375" height="50"/>
                     <color key="backgroundColor" red="0.1803921568627451" green="0.1803921568627451" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="50" id="Rgp-eD-N67"/>
@@ -63,7 +64,7 @@
                     </connections>
                 </button>
                 <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6Dl-Dt-Cf4">
-                    <rect key="frame" x="0.0" y="152" width="375" height="50"/>
+                    <rect key="frame" x="0.0" y="151" width="375" height="50"/>
                     <color key="backgroundColor" red="0.1803921568627451" green="0.1803921568627451" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="50" id="2BH-wR-G0B"/>
@@ -80,19 +81,19 @@
                     <rect key="frame" x="0.0" y="59" width="375" height="91"/>
                     <subviews>
                         <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eNa-sr-3In" userLabel="Name Label">
-                            <rect key="frame" x="86" y="22" width="44.5" height="22"/>
+                            <rect key="frame" x="86" y="22" width="45" height="22"/>
                             <fontDescription key="fontDescription" name="AvenirNext-Medium" family="Avenir Next" pointSize="16"/>
                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="@username" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pdg-bw-3Aj" userLabel="Username Label">
-                            <rect key="frame" x="86" y="47" width="75" height="19.5"/>
+                            <rect key="frame" x="86" y="47" width="75" height="20"/>
                             <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="14"/>
                             <color key="textColor" red="0.67843137254901964" green="0.6705882352941176" blue="0.6705882352941176" alpha="0.73999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vNd-VU-rPB" userLabel="Initials View">
-                            <rect key="frame" x="22" y="21.5" width="48" height="48"/>
+                            <rect key="frame" x="22" y="22" width="48" height="48"/>
                             <color key="backgroundColor" red="0.24705882352941178" green="0.24705882352941178" blue="0.2627450980392157" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
                                 <constraint firstAttribute="width" secondItem="vNd-VU-rPB" secondAttribute="height" multiplier="1:1" id="Aoh-t3-1c1"/>
@@ -104,7 +105,7 @@
                             </userDefinedRuntimeAttributes>
                         </view>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VyB-vO-lnH" userLabel="Initials Label">
-                            <rect key="frame" x="22" y="36.5" width="48" height="21"/>
+                            <rect key="frame" x="22" y="37" width="48" height="21"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="21" id="FTv-tK-j3A"/>
                             </constraints>
@@ -113,7 +114,7 @@
                             <nil key="highlightedColor"/>
                         </label>
                         <imageView hidden="YES" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="3LL-O1-glU">
-                            <rect key="frame" x="22" y="21.5" width="48" height="48"/>
+                            <rect key="frame" x="22" y="22" width="48" height="48"/>
                             <color key="backgroundColor" red="0.054901960784313725" green="0.047058823529411764" blue="0.047058823529411764" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="48" id="wAu-vO-QoY"/>
@@ -150,10 +151,10 @@
                     </constraints>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n8j-yT-ozA">
-                    <rect key="frame" x="0.0" y="333.5" width="375" height="50"/>
+                    <rect key="frame" x="0.0" y="308" width="375" height="50"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enable Notifications" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zSO-9T-0hZ">
-                            <rect key="frame" x="22" y="15.5" width="128" height="19.5"/>
+                            <rect key="frame" x="22" y="15" width="128" height="20"/>
                             <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="14"/>
                             <color key="textColor" red="0.67843137254901964" green="0.6705882352941176" blue="0.6705882352941176" alpha="0.73999999999999999" colorSpace="calibratedRGB"/>
                             <nil key="highlightedColor"/>
@@ -167,15 +168,40 @@
                     </constraints>
                 </view>
                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="TyH-kz-APS">
-                    <rect key="frame" x="311" y="343" width="51" height="31"/>
+                    <rect key="frame" x="311" y="318" width="51" height="31"/>
                     <color key="tintColor" red="0.67843137254901964" green="0.6705882352941176" blue="0.6705882352941176" alpha="0.73999999999999999" colorSpace="calibratedRGB"/>
                     <color key="thumbTintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <connections>
                         <action selector="toggledNotifications:" destination="-1" eventType="valueChanged" id="Jok-fh-Ykw"/>
                     </connections>
                 </switch>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EXq-o7-Xe5">
+                    <rect key="frame" x="0.0" y="359" width="375" height="50"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enable Music On App Exit" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="P1e-R7-gcx">
+                            <rect key="frame" x="22" y="15.5" width="166" height="19.5"/>
+                            <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="14"/>
+                            <color key="textColor" red="0.67843137249999996" green="0.6705882353" blue="0.6705882353" alpha="0.73999999999999999" colorSpace="calibratedRGB"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" red="0.18039215689999999" green="0.18039215689999999" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="50" id="DSx-ct-AaT"/>
+                        <constraint firstItem="P1e-R7-gcx" firstAttribute="centerY" secondItem="EXq-o7-Xe5" secondAttribute="centerY" id="pSD-3p-GCe"/>
+                        <constraint firstItem="P1e-R7-gcx" firstAttribute="leading" secondItem="EXq-o7-Xe5" secondAttribute="leading" constant="22" id="vlK-QI-DUn"/>
+                    </constraints>
+                </view>
+                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="vby-YR-amp">
+                    <rect key="frame" x="311" y="368" width="51" height="31"/>
+                    <color key="tintColor" red="0.67843137249999996" green="0.6705882353" blue="0.6705882353" alpha="0.73999999999999999" colorSpace="calibratedRGB"/>
+                    <color key="thumbTintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <connections>
+                        <action selector="toggledMusicOnExit:" destination="-1" eventType="valueChanged" id="wkH-6b-Ils"/>
+                    </connections>
+                </switch>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hCy-rO-jND">
-                    <rect key="frame" x="0.0" y="152" width="375" height="50"/>
+                    <rect key="frame" x="0.0" y="151" width="375" height="50"/>
                     <color key="backgroundColor" red="0.1803921568627451" green="0.1803921568627451" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="50" id="1xi-zu-cLS"/>
@@ -214,21 +240,26 @@
                 <constraint firstItem="POc-Cn-iow" firstAttribute="top" secondItem="6rq-4p-ZgW" secondAttribute="bottom" constant="11" id="DOn-kj-ur2"/>
                 <constraint firstAttribute="trailing" secondItem="TyH-kz-APS" secondAttribute="trailing" constant="15" id="FX9-aQ-ycP"/>
                 <constraint firstAttribute="trailing" secondItem="6Dl-Dt-Cf4" secondAttribute="trailing" id="HxB-nM-zlY"/>
-                <constraint firstItem="PTm-Qt-aaa" firstAttribute="top" secondItem="mPq-C5-plJ" secondAttribute="bottom" constant="50" id="IL6-9Y-Ta3"/>
+                <constraint firstItem="PTm-Qt-aaa" firstAttribute="top" secondItem="mPq-C5-plJ" secondAttribute="bottom" constant="25" id="IL6-9Y-Ta3"/>
                 <constraint firstItem="TyH-kz-APS" firstAttribute="centerY" secondItem="n8j-yT-ozA" secondAttribute="centerY" id="IN2-Dd-12q"/>
+                <constraint firstItem="vby-YR-amp" firstAttribute="centerY" secondItem="EXq-o7-Xe5" secondAttribute="centerY" id="IZ6-lx-HCu"/>
+                <constraint firstItem="EXq-o7-Xe5" firstAttribute="top" secondItem="n8j-yT-ozA" secondAttribute="bottom" constant="1" id="KZF-fh-wvd"/>
                 <constraint firstItem="mPq-C5-plJ" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="LAi-sl-Mye"/>
                 <constraint firstAttribute="trailing" secondItem="hCy-rO-jND" secondAttribute="trailing" id="YO2-ar-BpO"/>
                 <constraint firstItem="hCy-rO-jND" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="ZWt-mK-Qwh"/>
                 <constraint firstItem="6rq-4p-ZgW" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="30" id="cGT-bk-cAN"/>
                 <constraint firstAttribute="trailing" secondItem="n8j-yT-ozA" secondAttribute="trailing" id="dNM-vv-Rkx"/>
                 <constraint firstItem="POc-Cn-iow" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="dpV-Uo-eka"/>
-                <constraint firstItem="hCy-rO-jND" firstAttribute="top" secondItem="POc-Cn-iow" secondAttribute="bottom" constant="2" id="gOO-og-kCg"/>
-                <constraint firstItem="6Dl-Dt-Cf4" firstAttribute="top" secondItem="POc-Cn-iow" secondAttribute="bottom" constant="2" id="uiD-MC-NwK"/>
+                <constraint firstItem="hCy-rO-jND" firstAttribute="top" secondItem="POc-Cn-iow" secondAttribute="bottom" constant="1" id="gOO-og-kCg"/>
+                <constraint firstAttribute="trailing" secondItem="vby-YR-amp" secondAttribute="trailing" constant="15" id="idU-87-vJi"/>
+                <constraint firstItem="EXq-o7-Xe5" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="lnp-h9-QZJ"/>
+                <constraint firstAttribute="trailing" secondItem="EXq-o7-Xe5" secondAttribute="trailing" id="r1z-vF-ecP"/>
+                <constraint firstItem="6Dl-Dt-Cf4" firstAttribute="top" secondItem="POc-Cn-iow" secondAttribute="bottom" constant="1" id="uiD-MC-NwK"/>
                 <constraint firstItem="TyH-kz-APS" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="zSO-9T-0hZ" secondAttribute="trailing" constant="22" id="x2F-KY-WUT"/>
                 <constraint firstItem="n8j-yT-ozA" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="yXS-x4-HPh"/>
                 <constraint firstItem="mPq-C5-plJ" firstAttribute="top" secondItem="6Dl-Dt-Cf4" secondAttribute="bottom" constant="1" id="zOQ-uH-uu3"/>
             </constraints>
-            <point key="canvasLocation" x="1408" y="280"/>
+            <point key="canvasLocation" x="1407.5" y="279.5"/>
         </view>
     </objects>
 </document>

--- a/Tempo/Models/Post.swift
+++ b/Tempo/Models/Post.swift
@@ -87,6 +87,6 @@ class Post: NSObject {
 	}
 	
 	func equals(other: Post) -> Bool {
-		return song.equals(other: other.song) && user.equals(other: other.user)
+		return postID == other.postID
 	}
 }

--- a/Tempo/PlayerNavigationController.swift
+++ b/Tempo/PlayerNavigationController.swift
@@ -22,6 +22,7 @@ class PlayerNavigationController: UINavigationController, PostDelegate {
 	private var expandedCell: ExpandedPlayerView!
 	let expandedHeight: CGFloat = 347
 	
+	var postView: PostView?
 	var postsRef: [Post]?
 	var postRefIndex: Int?
 	var playingPostType: PlayingPostType?
@@ -94,5 +95,21 @@ class PlayerNavigationController: UINavigationController, PostDelegate {
 	func updateAddButton() {
 		playerCell.updateAddButton()
 		expandedCell.updateAddButton()
+	}
+	
+	func togglePause() {
+		if let post = currentPost, post.player.isPlaying {
+			post.player.togglePlaying()
+			post.player.progress = 0.0
+			expandedCell.progressView.setNeedsDisplay()
+			playerCell.progressView.setNeedsDisplay()
+			updatePlayingStatus()
+		}
+	}
+	
+	func toggleAvatarAnimation(){
+		if let post = currentPost, post.player.isPlaying {
+			post.player.pause()
+		}
 	}
 }

--- a/Tempo/PlayerNavigationController.swift
+++ b/Tempo/PlayerNavigationController.swift
@@ -22,17 +22,21 @@ class PlayerNavigationController: UINavigationController, PostDelegate {
 	private var expandedCell: ExpandedPlayerView!
 	let expandedHeight: CGFloat = 347
 	
-	var postView: PostView?
-	var postsRef: [Post]?
-	var postRefIndex: Int?
-	var playingPostType: PlayingPostType?
 	var currentPost: Post? {
 		didSet {
 			if let newPost = currentPost {
+				//deal with previous post
+				oldValue?.player.progress = 0
+				oldValue?.player.pause()
+				postView?.updatePlayingStatus()
 				updatePlayerCells(newPost: newPost)
 			}
 		}
 	}
+	var postView: PostView?
+	var postsRef: [Post]?
+	var postRefIndex: Int?
+	var playingPostType: PlayingPostType?
 	var playerDelegate: PlayerDelegate?
 	
 	override func viewDidLoad() {
@@ -103,13 +107,8 @@ class PlayerNavigationController: UINavigationController, PostDelegate {
 			post.player.progress = 0.0
 			expandedCell.progressView.setNeedsDisplay()
 			playerCell.progressView.setNeedsDisplay()
+			postView?.updatePlayingStatus()
 			updatePlayingStatus()
-		}
-	}
-	
-	func toggleAvatarAnimation(){
-		if let post = currentPost, post.player.isPlaying {
-			post.player.pause()
 		}
 	}
 }

--- a/Tempo/Profile/FeedTableViewCell.xib
+++ b/Tempo/Profile/FeedTableViewCell.xib
@@ -22,11 +22,11 @@
             <rect key="frame" x="0.0" y="0.0" width="349" height="111"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="349" height="110"/>
+                <rect key="frame" x="0.0" y="0.0" width="349" height="110.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QJt-Cq-8SO" customClass="PostView" customModule="Tempo" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="0.0" width="349" height="110.5"/>
+                    <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QJt-Cq-8SO" customClass="FeedPostView" customModule="Tempo" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="0.0" width="349" height="110"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="30m" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5c9-Vi-T55">
                                 <rect key="frame" x="295" y="26" width="32" height="18"/>
@@ -38,7 +38,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Mark Bryan" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YKr-CE-jlM">
-                                <rect key="frame" x="102" y="22" width="83.5" height="22"/>
+                                <rect key="frame" x="102" y="22" width="84" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="22" id="Dgf-vZ-mOF"/>
                                 </constraints>
@@ -47,7 +47,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Reflections · MisterWives" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uOI-Pn-Mde">
-                                <rect key="frame" x="102" y="45" width="158.5" height="22"/>
+                                <rect key="frame" x="102" y="45" width="159" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="22" id="PaO-Cc-c1t"/>
                                 </constraints>
@@ -90,7 +90,7 @@
                                 </constraints>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6mr-Fh-ZfQ">
-                                <rect key="frame" x="308" y="66.5" width="19" height="17"/>
+                                <rect key="frame" x="308" y="66" width="19" height="17"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="17" id="9hG-vk-Btv"/>
                                     <constraint firstAttribute="width" constant="30" id="LDw-C6-eoZ"/>
@@ -149,6 +149,13 @@
                         </constraints>
                         <variation key="default">
                             <mask key="constraints">
+                                <exclude reference="79W-Kx-Dih"/>
+                                <exclude reference="z8L-dh-MBU"/>
+                                <exclude reference="Qm8-3A-vx8"/>
+                                <exclude reference="eap-fr-BWT"/>
+                                <exclude reference="NnZ-WN-LLM"/>
+                                <exclude reference="bgX-rg-DvA"/>
+                                <exclude reference="2LY-CJ-qI7"/>
                                 <exclude reference="7C3-75-21p"/>
                                 <exclude reference="8RL-a6-Rty"/>
                                 <exclude reference="LjR-Es-b0P"/>
@@ -160,27 +167,20 @@
                                 <exclude reference="NBM-qT-a6T"/>
                                 <exclude reference="QyV-y4-BeW"/>
                                 <exclude reference="ris-zv-Z5S"/>
-                                <exclude reference="79W-Kx-Dih"/>
-                                <exclude reference="z8L-dh-MBU"/>
-                                <exclude reference="Qm8-3A-vx8"/>
-                                <exclude reference="eap-fr-BWT"/>
-                                <exclude reference="2LY-CJ-qI7"/>
-                                <exclude reference="NnZ-WN-LLM"/>
-                                <exclude reference="bgX-rg-DvA"/>
                             </mask>
                         </variation>
                         <connections>
                             <outlet property="avatarImageView" destination="Nid-NE-gCm" id="tOJ-nl-KG3"/>
-                            <outlet property="dateLabel" destination="5c9-Vi-T55" id="OPV-kq-To8"/>
-                            <outlet property="descriptionLabel" destination="uOI-Pn-Mde" id="KMS-oB-AtZ"/>
+                            <outlet property="dateLabel" destination="5c9-Vi-T55" id="QYe-1c-MPG"/>
+                            <outlet property="descriptionLabel" destination="uOI-Pn-Mde" id="vM5-cO-Wdn"/>
                             <outlet property="likedButton" destination="6mr-Fh-ZfQ" id="cPl-NE-hM2"/>
-                            <outlet property="likesLabel" destination="bgO-bG-1rj" id="ByJ-k3-GUD"/>
-                            <outlet property="profileNameLabel" destination="YKr-CE-jlM" id="rGa-cb-aYR"/>
+                            <outlet property="likesLabel" destination="bgO-bG-1rj" id="3Rn-dB-yr5"/>
+                            <outlet property="profileNameLabel" destination="YKr-CE-jlM" id="Bwl-22-YhW"/>
                             <outlet property="spacingConstraint" destination="Qm8-3A-vx8" id="irB-iZ-PBy"/>
                         </connections>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uAH-9e-ILc" userLabel="Separator">
-                        <rect key="frame" x="0.0" y="109.5" width="349" height="1"/>
+                        <rect key="frame" x="0.0" y="109" width="349" height="1"/>
                         <color key="backgroundColor" red="0.11372549019607843" green="0.11764705882352941" blue="0.12156862745098039" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" id="z2S-lx-eF2"/>

--- a/Tempo/Profile/FeedTableViewCell.xib
+++ b/Tempo/Profile/FeedTableViewCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16B2657" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -22,7 +22,7 @@
             <rect key="frame" x="0.0" y="0.0" width="349" height="111"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="349" height="110.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="349" height="110"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QJt-Cq-8SO" customClass="FeedPostView" customModule="Tempo" customModuleProvider="target">
@@ -210,12 +210,12 @@
                 </variation>
             </tableViewCellContentView>
             <connections>
+                <outlet property="feedPostView" destination="QJt-Cq-8SO" id="Ret-34-hz6"/>
                 <outlet property="imageViewTopConstraint" destination="qLD-Yk-BfD" id="e3i-Ta-42O"/>
                 <outlet property="imageViewWidthConstraint" destination="OQ3-QG-Xnp" id="dwf-Mp-aDn"/>
                 <outlet property="initialsLabel" destination="R0m-id-5JG" id="HGx-mA-Axm"/>
                 <outlet property="initialsView" destination="pse-mG-Eo3" id="Nrv-1h-g49"/>
                 <outlet property="likeButtonBottomConstraint" destination="cp3-qB-PmE" id="jXb-31-aP8"/>
-                <outlet property="postView" destination="QJt-Cq-8SO" id="8YT-SU-qgm"/>
                 <outlet property="separator" destination="uAH-9e-ILc" id="Up3-YJ-jcN"/>
                 <outlet property="separatorHeight" destination="z2S-lx-eF2" id="4g4-TS-hj6"/>
             </connections>

--- a/Tempo/Supporting Files/Info.plist
+++ b/Tempo/Supporting Files/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.0.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>70</string>
+	<string>1</string>
 	<key>FacebookAppID</key>
 	<string>977907382286912</string>
 	<key>FacebookDisplayName</key>

--- a/Tempo/Views/FeedPostView.swift
+++ b/Tempo/Views/FeedPostView.swift
@@ -1,0 +1,207 @@
+//
+//  FeedPostView.swift
+//  Tempo
+//
+//  Created by Keivan Shahida on 2/22/17.
+//  Copyright © 2017 CUAppDev. All rights reserved.
+//
+
+import UIKit
+import MediaPlayer
+import Haneke
+
+class FeedPostView: PostView {
+	fileprivate var tapGestureRecognizer: UITapGestureRecognizer?
+	fileprivate var longPressGestureRecognizer: UILongPressGestureRecognizer?
+	@IBOutlet var profileNameLabel: UILabel?
+	@IBOutlet var avatarImageView: UIImageView?
+	@IBOutlet var descriptionLabel: UILabel?
+	@IBOutlet var dateLabel: UILabel?
+	@IBOutlet var spacingConstraint: NSLayoutConstraint?
+	@IBOutlet var likesLabel: UILabel?
+	@IBOutlet var likedButton: UIButton?
+	let fillColor = UIColor.tempoDarkGray
+ 
+	var type: ViewType = .feed
+	var songStatus: SavedSongStatus = .notSaved
+	var postViewDelegate: PostViewDelegate!
+	var playerDelegate: PlayerDelegate!
+	
+	var playerController: PlayerTableViewController?
+	
+	var post: Post? {
+		didSet {
+			if let post = post {
+				switch type {
+				case .feed:
+					avatarImageView?.layer.cornerRadius = avatarImageView!.bounds.size.width / 2
+					profileNameLabel?.text = "\(post.user.firstName) \(post.user.shortenLastName())"
+					descriptionLabel?.text = "\(post.song.title) · \(post.song.artist)"
+					likesLabel?.text = (post.likes == 1) ? "\(post.likes) like" : "\(post.likes) likes"
+					let imageName = post.isLiked ? "LikedButton" : "LikeButton"
+					likedButton?.setBackgroundImage(UIImage(named: imageName), for: .normal)
+					dateLabel?.text = post.relativeDate()
+				case .history:
+					profileNameLabel?.text = post.song.title
+					descriptionLabel?.text = post.song.artist
+					likesLabel?.text = (post.likes == 1) ? "\(post.likes) like" : "\(post.likes) likes"
+					let imageName = post.isLiked ? "LikedButton" : "LikeButton"
+					likedButton?.setBackgroundImage(UIImage(named: imageName), for: .normal)
+				}
+				
+				switch type {
+				case .feed:
+					avatarImageView?.hnk_setImageFromURL(post.user.imageURL)
+				case .history:
+					avatarImageView?.hnk_setImageFromURL(post.song.smallArtworkURL ?? URL(fileURLWithPath: ""))
+				}
+				
+				//! TODO: Write something that makes this nice and relative
+				//! that updates every minute
+				
+				if User.currentUser.currentSpotifyUser?.savedTracks[post.song.spotifyID] != nil {
+					songStatus = .saved
+				}
+			}
+		}
+	}
+	
+	// Called from delegate whenever player is toggled
+	override func updatePlayingStatus() {
+		updateProfileLabel()
+		updateBackground()
+	}
+	
+	func updateDateLabel() {
+		self.dateLabel!.isHidden = true
+		SpotifyController.sharedController.spotifyIsAvailable { success in
+			if success {
+				self.dateLabel!.isHidden = false
+			}
+		}
+	}
+	
+	override func didMoveToWindow() {
+		
+		if tapGestureRecognizer == nil {
+			tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(postViewPressed(_:)))
+			tapGestureRecognizer?.delegate = self
+			tapGestureRecognizer?.cancelsTouchesInView = false
+			addGestureRecognizer(tapGestureRecognizer!)
+		}
+		
+		if longPressGestureRecognizer == nil {
+			longPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(postViewPressed(_:)))
+			longPressGestureRecognizer?.delegate = self
+			longPressGestureRecognizer?.minimumPressDuration = 0.5
+			longPressGestureRecognizer?.cancelsTouchesInView = false
+			addGestureRecognizer(longPressGestureRecognizer!)
+		}
+		
+		avatarImageView?.clipsToBounds = true
+		isUserInteractionEnabled = true
+		avatarImageView?.isUserInteractionEnabled = true
+		profileNameLabel?.isUserInteractionEnabled = true
+		
+		layer.borderColor = UIColor.tempoDarkGray.cgColor
+		layer.borderWidth = 0.7
+	}
+	
+	override func didMoveToSuperview() {
+		super.didMoveToSuperview()
+		
+		if superview != nil && dateLabel != nil {
+			spacingConstraint?.constant = (dateLabel!.frame.origin.x - superview!.frame.size.width) + 8
+		}
+	}
+	
+	override func layoutSubviews() {
+		super.layoutSubviews()
+		likedButton?.tag = 1
+		updateProfileLabel()
+		updateBackground()
+	}
+	
+	// Customize view to be able to re-use it for search results.
+	func flagAsSearchResultPost() {
+		descriptionLabel?.text = post!.song.title + " · " + post!.song.album
+	}
+	
+	override func updateProfileLabel() {
+		let avatarLayer = avatarImageView?.layer
+		if let layer = avatarLayer {
+			layer.transform = CATransform3DIdentity
+			layer.removeAnimation(forKey: "transform.rotation")
+		}
+		
+		if let post = post {
+			let color: UIColor
+			let font = UIFont(name: "Avenir-Medium", size: 16)!
+			let duration = TimeInterval(0.3)
+			if post.player.isPlaying {
+				color = .tempoRed
+				if type == .feed {
+					if let layer = avatarLayer {
+						let animation = CABasicAnimation(keyPath: "transform.rotation")
+						animation.fromValue = 0
+						animation.duration = 3 * M_PI
+						animation.toValue = 2 * M_PI
+						animation.repeatCount = FLT_MAX
+						layer.add(animation, forKey: "transform.rotation")
+					}
+				}
+			} else {
+				color = UIColor.white
+			}
+			
+			guard let label = profileNameLabel else { return }
+			if !label.textColor.isEqual(color) {
+				UIView.transition(with: label, duration: duration, options: .transitionCrossDissolve, animations: {
+					label.textColor = color
+					label.font = font
+				}, completion: { _ in
+					label.textColor = color
+					label.font = font
+				})
+			}
+		}
+	}
+	
+	override func updateBackground() {
+		if let post = post {
+			if type == .feed {
+				backgroundColor = post.player.wasPlayed ? .readCellColor : .unreadCellColor
+			} else {
+				backgroundColor = post.player.isPlaying ? .readCellColor : .unreadCellColor
+			}
+		}
+	}
+	
+	
+	func postViewPressed(_ sender: UIGestureRecognizer) {
+		guard let post = post else { return }
+		
+		if sender is UITapGestureRecognizer {
+			let tapPoint = sender.location(in: self)
+			let hitView = hitTest(tapPoint, with: nil)
+			let tapPointX = tapPoint.x
+			if (tapPointX + 4.0) < (avatarImageView?.frame.maxX)! {
+				postViewDelegate?.didTapImageForPostView?(post)
+			}
+			if hitView == likedButton {
+				post.toggleLike()
+				updateLikedStatus()
+				playerDelegate.didToggleLike!()
+			}
+		}
+	}
+	
+	func updateLikedStatus() {
+		if let post = post {
+			let name = post.isLiked ? "LikedButton" : "LikeButton"
+			likesLabel?.text = (post.likes == 1) ? "\(post.likes) like" : "\(post.likes) likes"
+			likedButton?.setBackgroundImage(UIImage(named: name), for: .normal)
+		}
+	}
+}
+

--- a/Tempo/Views/FeedPostView.swift
+++ b/Tempo/Views/FeedPostView.swift
@@ -29,7 +29,7 @@ class FeedPostView: PostView {
 	
 	var playerController: PlayerTableViewController?
 	
-	var post: Post? {
+	override var post: Post? {
 		didSet {
 			if let post = post {
 				switch type {

--- a/Tempo/Views/FeedTableViewCell.swift
+++ b/Tempo/Views/FeedTableViewCell.swift
@@ -8,9 +8,9 @@
 
 import UIKit
 
-class FeedTableViewCell: UITableViewCell {
+class FeedTableViewCell: PostTableViewCell {
 	
-    @IBOutlet var postView: PostView!
+    @IBOutlet weak var feedPostView: FeedPostView!
     @IBOutlet weak var initialsView: UIView!
     @IBOutlet weak var initialsLabel: UILabel!
     @IBOutlet weak var separator: UIView!
@@ -22,20 +22,22 @@ class FeedTableViewCell: UITableViewCell {
 	override func awakeFromNib() {
 		super.awakeFromNib()
 		
-		postView.backgroundColor = .unreadCellColor
+		postView?.backgroundColor = .unreadCellColor
 		separator.backgroundColor = .readCellColor
 		separatorHeight.constant = 1
 	}
 	
-	func setUpCell(firstName: String, lastName: String) {
+	func setUpFeedCell(firstName: String, lastName: String) {
+		postView = feedPostView
 		initialsLabel.text = setUserInitials(firstName: firstName, lastName: lastName)
 	}
 	
 	func setUpPostHistoryCell() {
+		postView = feedPostView
 		initialsLabel.text = ""
 		initialsView.isHidden = true
-		postView.dateLabel!.isHidden = true
-		postView.avatarImageView?.layer.cornerRadius = 0
+		feedPostView.dateLabel!.isHidden = true
+		feedPostView.avatarImageView?.layer.cornerRadius = 0
 		imageViewWidthConstraint.constant = 60
 		imageViewTopConstraint.constant = 25
 		likeButtonBottomConstraint.constant = 48.5

--- a/Tempo/Views/LikedPostView.swift
+++ b/Tempo/Views/LikedPostView.swift
@@ -34,7 +34,7 @@ class LikedPostView: PostView {
 	
 	var playerController: PlayerTableViewController?
 	
-	var post: Post? {
+	override var post: Post? {
 		didSet {
 			// update stuff
 			if let post = post {

--- a/Tempo/Views/LikedPostView.swift
+++ b/Tempo/Views/LikedPostView.swift
@@ -10,7 +10,7 @@ import UIKit
 import MediaPlayer
 import Haneke
 
-class LikedPostView: UIView, UIGestureRecognizerDelegate {
+class LikedPostView: PostView {
 	fileprivate var tapGestureRecognizer: UITapGestureRecognizer?
 	fileprivate var longPressGestureRecognizer: UILongPressGestureRecognizer?
 	
@@ -89,7 +89,7 @@ class LikedPostView: UIView, UIGestureRecognizerDelegate {
 		addSubview(addButton!)
 	}
 	
-	func updatePlayingStatus() {
+	override func updatePlayingStatus() {
 		updateSongLabel()
 		updateBackground()
 	}
@@ -158,7 +158,7 @@ class LikedPostView: UIView, UIGestureRecognizerDelegate {
 		}
 	}
 	
-	func updateBackground() {
+	override func updateBackground() {
 		if let post = post {
 			backgroundColor = post.player.isPlaying ? .readCellColor : .unreadCellColor
 		}

--- a/Tempo/Views/LikedTableViewCell.swift
+++ b/Tempo/Views/LikedTableViewCell.swift
@@ -8,9 +8,9 @@
 
 import UIKit
 
-class LikedTableViewCell: UITableViewCell {
+class LikedTableViewCell: PostTableViewCell {
 	
-	var postView: LikedPostView?
+	var likedPostView: LikedPostView? = nil
 	var separator: UIView?
 
     override func awakeFromNib() {
@@ -19,10 +19,10 @@ class LikedTableViewCell: UITableViewCell {
 	
 	func setupCell(spotifyAvailable: Bool) {
 		selectionStyle = .none
-		
-		postView = LikedPostView()
-		postView?.frame = bounds
-		postView?.isSpotifyAvailable = spotifyAvailable
+		likedPostView = LikedPostView()
+		postView = likedPostView as PostView?
+		likedPostView?.frame = bounds
+		likedPostView?.isSpotifyAvailable = spotifyAvailable
 		addSubview(postView!)
 		
 		separator = UIView(frame: CGRect(x: 0, y: bounds.height - 1, width: bounds.width, height: 1))

--- a/Tempo/Views/PostTableViewCell.swift
+++ b/Tempo/Views/PostTableViewCell.swift
@@ -1,0 +1,26 @@
+//
+//  PostTableViewCell.swift
+//  Tempo
+//
+//  Created by Jesse Chen on 2/26/17.
+//  Copyright © 2017 CUAppDev. All rights reserved.
+//
+
+import UIKit
+
+class PostTableViewCell: UITableViewCell {
+	
+	var postView: PostView?
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+
+}

--- a/Tempo/Views/PostView.swift
+++ b/Tempo/Views/PostView.swift
@@ -28,196 +28,22 @@ enum SavedSongStatus: Int {
 }
 
 class PostView: UIView, UIGestureRecognizerDelegate {
-	fileprivate var tapGestureRecognizer: UITapGestureRecognizer?
-	fileprivate var longPressGestureRecognizer: UILongPressGestureRecognizer?
-	@IBOutlet var profileNameLabel: UILabel?
-	@IBOutlet var avatarImageView: UIImageView?
-	@IBOutlet var descriptionLabel: UILabel?
-	@IBOutlet var dateLabel: UILabel?
-	@IBOutlet var spacingConstraint: NSLayoutConstraint?
-	@IBOutlet var likesLabel: UILabel?
-	@IBOutlet var likedButton: UIButton?
-	let fillColor = UIColor.tempoDarkGray
- 
-	var type: ViewType = .feed
-	var songStatus: SavedSongStatus = .notSaved
-	var postViewDelegate: PostViewDelegate!
-	var playerDelegate: PlayerDelegate!
-	
-	var playerController: PlayerTableViewController?
-	
-	var post: Post? {
-		didSet {
-			if let post = post {
-				switch type {
-				case .feed:
-					avatarImageView?.layer.cornerRadius = avatarImageView!.bounds.size.width / 2
-					profileNameLabel?.text = "\(post.user.firstName) \(post.user.shortenLastName())"
-					descriptionLabel?.text = "\(post.song.title) · \(post.song.artist)"
-					likesLabel?.text = (post.likes == 1) ? "\(post.likes) like" : "\(post.likes) likes"
-					let imageName = post.isLiked ? "LikedButton" : "LikeButton"
-					likedButton?.setBackgroundImage(UIImage(named: imageName), for: .normal)
-					dateLabel?.text = post.relativeDate()
-				case .history:
-					profileNameLabel?.text = post.song.title
-					descriptionLabel?.text = post.song.artist
-					likesLabel?.text = (post.likes == 1) ? "\(post.likes) like" : "\(post.likes) likes"
-					let imageName = post.isLiked ? "LikedButton" : "LikeButton"
-					likedButton?.setBackgroundImage(UIImage(named: imageName), for: .normal)
-				}
-				
-				switch type {
-				case .feed:
-					avatarImageView?.hnk_setImageFromURL(post.user.imageURL)
-				case .history:
-					avatarImageView?.hnk_setImageFromURL(post.song.smallArtworkURL ?? URL(fileURLWithPath: ""))
-				}
-				
-				//! TODO: Write something that makes this nice and relative
-				//! that updates every minute
-				
-				if User.currentUser.currentSpotifyUser?.savedTracks[post.song.spotifyID] != nil {
-					songStatus = .saved
-				}
-			}
-		}
-	}
-	
-	// Called from delegate whenever player it toggled
+
+	// Called from delegate whenever player is toggled
 	func updatePlayingStatus() {
 		updateProfileLabel()
 		updateBackground()
 	}
 	
-	func updateDateLabel() {
-		self.dateLabel!.isHidden = true
-		SpotifyController.sharedController.spotifyIsAvailable { success in
-			if success {
-				self.dateLabel!.isHidden = false
-			}
-		}
+	func updateProfileLabel(){
+		preconditionFailure("This method must be overriden")
+	}
+	
+	func updateBackground(){
+		preconditionFailure("This method must be overriden")
 	}
 	
 	override func didMoveToWindow() {
-		
-		if tapGestureRecognizer == nil {
-			tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(postViewPressed(_:)))
-			tapGestureRecognizer?.delegate = self
-			tapGestureRecognizer?.cancelsTouchesInView = false
-			addGestureRecognizer(tapGestureRecognizer!)
-		}
-		
-		if longPressGestureRecognizer == nil {
-			longPressGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(postViewPressed(_:)))
-			longPressGestureRecognizer?.delegate = self
-			longPressGestureRecognizer?.minimumPressDuration = 0.5
-			longPressGestureRecognizer?.cancelsTouchesInView = false
-			addGestureRecognizer(longPressGestureRecognizer!)
-		}
-		
-		avatarImageView?.clipsToBounds = true
-		isUserInteractionEnabled = true
-		avatarImageView?.isUserInteractionEnabled = true
-		profileNameLabel?.isUserInteractionEnabled = true
-		
-		layer.borderColor = UIColor.tempoDarkGray.cgColor
-		layer.borderWidth = 0.7
-	}
-	
-	override func didMoveToSuperview() {
-		super.didMoveToSuperview()
-		
-		if superview != nil && dateLabel != nil {
-			spacingConstraint?.constant = (dateLabel!.frame.origin.x - superview!.frame.size.width) + 8
-		}
-	}
-	
-	override func layoutSubviews() {
-		super.layoutSubviews()
-		likedButton?.tag = 1
-		updateProfileLabel()
-		updateBackground()
-	}
-	
-	// Customize view to be able to re-use it for search results.
-	func flagAsSearchResultPost() {
-		descriptionLabel?.text = post!.song.title + " · " + post!.song.album
-	}
-	
-	func updateProfileLabel() {
-		let avatarLayer = avatarImageView?.layer
-		if let layer = avatarLayer {
-			layer.transform = CATransform3DIdentity
-			layer.removeAnimation(forKey: "transform.rotation")
-		}
-		
-		if let post = post {
-			let color: UIColor
-			let font = UIFont(name: "Avenir-Medium", size: 16)!
-			let duration = TimeInterval(0.3)
-			if post.player.isPlaying {
-				color = .tempoRed
-				if type == .feed {
-					if let layer = avatarLayer {
-						let animation = CABasicAnimation(keyPath: "transform.rotation")
-						animation.fromValue = 0
-						animation.duration = 3 * M_PI
-						animation.toValue = 2 * M_PI
-						animation.repeatCount = FLT_MAX
-						layer.add(animation, forKey: "transform.rotation")
-					}
-				}
-			} else {
-				color = UIColor.white
-			}
-			
-			guard let label = profileNameLabel else { return }
-			if !label.textColor.isEqual(color) {
-				UIView.transition(with: label, duration: duration, options: .transitionCrossDissolve, animations: {
-					label.textColor = color
-					label.font = font
-				}, completion: { _ in
-					label.textColor = color
-					label.font = font
-				})
-			}
-		}
-	}
-	
-	func updateBackground() {
-		if let post = post {
-			if type == .feed {
-				backgroundColor = post.player.wasPlayed ? .readCellColor : .unreadCellColor
-			} else {
-				backgroundColor = post.player.isPlaying ? .readCellColor : .unreadCellColor
-			}
-		}
-	}
-	
-	
-	func postViewPressed(_ sender: UIGestureRecognizer) {
-		guard let post = post else { return }
-		
-		if sender is UITapGestureRecognizer {
-			let tapPoint = sender.location(in: self)
-			let hitView = hitTest(tapPoint, with: nil)
-			let tapPointX = tapPoint.x
-			if (tapPointX + 4.0) < (avatarImageView?.frame.maxX)! {
-				postViewDelegate?.didTapImageForPostView?(post)
-			}
-			if hitView == likedButton {
-				post.toggleLike()
-				updateLikedStatus()
-				playerDelegate.didToggleLike!()
-			}
-		}
-	}
-	
-	func updateLikedStatus() {
-		if let post = post {
-			let name = post.isLiked ? "LikedButton" : "LikeButton"
-			likesLabel?.text = (post.likes == 1) ? "\(post.likes) like" : "\(post.likes) likes"
-			likedButton?.setBackgroundImage(UIImage(named: name), for: .normal)
-		}
+		preconditionFailure("This method must be overriden")
 	}
 }

--- a/Tempo/Views/PostView.swift
+++ b/Tempo/Views/PostView.swift
@@ -28,6 +28,8 @@ enum SavedSongStatus: Int {
 }
 
 class PostView: UIView, UIGestureRecognizerDelegate {
+	
+	var post: Post?
 
 	// Called from delegate whenever player is toggled
 	func updatePlayingStatus() {


### PR DESCRIPTION
Originally this was a simple "disable music on app exit option" task, but we realized that a lot of the front-end architecture was pretty disorganized when we found it very difficult to implement such a simple feature. Therefore, along with that feature is a pretty big refactoring of the entire music-playing flow, as well as animations. 

With our addition of the "playerCell" last semester, we can centralize our logic around this new construct. Before, we had a bunch of logic all in a `didSet` around `currentlyPlayingIndex` to deal with the pausing/playing of old songs and new, as well as animations. I've been putting more responsibility to `playerNav`, which is what we call the `PlayerNavigationController`. `playerNav` is the primary interface for all the subclasses of `PlayerTableViewController` to interact with the `playerCell` and `expandedPlayer`. It is also the primary reference for stuff like: 
- which song is currently playing
- which postview is associated with the playing song
- which tableView is the song playing  

The major reason for this organization is the tableViews are not reliable; for example, LikedTableViewController will refresh every time you go back to the view. FeedVC can be manually refreshed. With those 3 pieces of information listed above, we can successfully determine whether a specific cell is the appropriate playing cell after a refresh, and we can then animate as necessary.

Another thing was inheritance; Keivan and I superclassed `FeedPostView` (originally `PostView`) and `LikedPostView` with `PostView`, which has the methods for updating the animation. We also superclassed `FeedTableViewCell` and `LikedTableViewCell` with `PostTableViewCell`, which has the core characteristic of having a field `postView`. This just makes the code a lot cleaner.

Finally, the animations were previously very buggy; much of this was because of the reusable cells of tableViews. Now, the logic is simplified:
- On `viewWillAppear`, we iterate through all the tableView cells that are visible, and update their animation status.
- On `cellForRow`, we do a check to see whether that cell is currently being played, and update their animation status appropriately. There is also a notion of what I call a `transplant`, which basically updates the postView being remembered by the `playerNav` if necessary. This is to maintain the invariant that the `playerNav` always has the most up to date information. 

I think these changes will make adding new features much easier in the future. 

I tested a decent amount and everything seems fine to me. I kinda want to merge this in ASAP, since it's a huge PR and it will almost definitely cause everybody merge conflicts. Even if people find new bugs, I would rather merge this in soon and fix them later. 