### PR TITLE
Move postType logic into Post class, fix some critical bugs from prev…

### DIFF
--- a/Tempo/Controllers/FeedViewController.swift
+++ b/Tempo/Controllers/FeedViewController.swift
@@ -181,13 +181,13 @@ class FeedViewController: PlayerTableViewController, SongSearchDelegate, FeedFol
 	
 	func continueAnimatingAfterRefresh() {
 		//animate currently playing song
-		if let playerCellPost = self.playerNav.currentPost, playerNav.playingPostType == .feed {
+		if let currentPost = self.playerNav.currentPost, currentPost.postType == .feed {
 			for row in 0 ..< posts.count {
-				if posts[row].equals(other: playerCellPost) {
-					posts[row] = playerCellPost
+				if posts[row].equals(other: currentPost) {
+					posts[row] = currentPost
 					let indexPath = IndexPath(row: row, section: 0)
 					if let cell = tableView.cellForRow(at: indexPath) as? FeedTableViewCell {
-						cell.feedPostView.post = playerCellPost
+						cell.feedPostView.post = currentPost
 						cell.feedPostView.updatePlayingStatus()
 					}
 					break

--- a/Tempo/Controllers/LikedTableViewController.swift
+++ b/Tempo/Controllers/LikedTableViewController.swift
@@ -55,7 +55,7 @@ class LikedTableViewController: PlayerTableViewController {
 		cell.likedPostView?.postViewDelegate = self
 		cell.likedPostView?.playerDelegate = self
 		cell.likedPostView?.updatePlayingStatus()
-		
+
 		transplantPlayerAndPostViewIfNeeded(cell: cell)
 		
 		return cell

--- a/Tempo/Models/Post.swift
+++ b/Tempo/Models/Post.swift
@@ -14,6 +14,7 @@ class Post: NSObject {
     var player: Player!
 	let song: Song
     let date: Date?
+	var postType: PlayingPostType
     fileprivate(set) var likes: Int
 	fileprivate(set) var isLiked: Bool = false
 	fileprivate(set) var postID: String = ""
@@ -30,6 +31,8 @@ class Post: NSObject {
         } else {
             player = Player(fileURL: URL(string: "https://p.scdn.co/mp3-preview/004eaa8d0769f3d464992704d9b5c152b862aa65")!)
         }
+		
+		postType = .unknown
         
         super.init()
     }
@@ -87,6 +90,11 @@ class Post: NSObject {
 	}
 	
 	func equals(other: Post) -> Bool {
-		return postID == other.postID
+		// special case with comparing "liked" posts, since there is no postID
+		if postType == .liked && other.postType == .liked {
+			return song.equals(other: other.song) && user.equals(other: other.user)
+		} else {
+			return postID == other.postID && postType == other.postType
+		}
 	}
 }

--- a/Tempo/PlayerNavigationController.swift
+++ b/Tempo/PlayerNavigationController.swift
@@ -36,7 +36,6 @@ class PlayerNavigationController: UINavigationController, PostDelegate {
 	var postView: PostView?
 	var postsRef: [Post]?
 	var postRefIndex: Int?
-	var playingPostType: PlayingPostType?
 	var playerDelegate: PlayerDelegate?
 	
 	override func viewDidLoad() {

--- a/Tempo/Views/ExpandedPlayerView.swift
+++ b/Tempo/Views/ExpandedPlayerView.swift
@@ -253,9 +253,9 @@ class ExpandedPlayerView: ParentPlayerCellView, UIGestureRecognizerDelegate {
 	
 	func updateLikeButton() {
 		if let selectedPost = post {
-			let name = (selectedPost.isLiked || playerNav.playingPostType == .liked) ? "LikedButton" : "PlayerLikeButton"
+			let name = (selectedPost.isLiked || selectedPost.postType == .liked) ? "LikedButton" : "PlayerLikeButton"
 			likeButtonImage.image = UIImage(named: name)
-			likeButtonLabel.text = (selectedPost.isLiked || playerNav.playingPostType == .liked)  ? "Liked" : "Like"
+			likeButtonLabel.text = (selectedPost.isLiked || selectedPost.postType == .liked)  ? "Liked" : "Like"
 		}
 	}
 	

--- a/Tempo/Views/PlayerCellView.swift
+++ b/Tempo/Views/PlayerCellView.swift
@@ -122,7 +122,7 @@ class PlayerCellView: ParentPlayerCellView {
 	
 	func updateLikeButton() {
 		if let selectedPost = post {
-			let name = (selectedPost.isLiked || playerNav.playingPostType == .liked) ? "LikedButton" : "LikeButton"
+			let name = (selectedPost.isLiked || selectedPost.postType == .liked) ? "LikedButton" : "LikeButton"
 			likeButton?.setBackgroundImage(UIImage(named: name), for: .normal)
 		}
 	}


### PR DESCRIPTION
…ious refactoring

Now we have a postType field in Post, which represents whether it's a post from .feed, .history, or .liked. That way, it's more intuitive in how we compare posts (same posts have to have the same type).

Posts from .liked don't have postIDs, so Post equality will take into account whether it is a .liked post. If it is, then we compare the song and the user.
Otherwise, for all other types, we just compare the postID, and make sure they have the same types.

Also fixes crashes that occur when a song finishes playing. That was happening because I was force unwrapping `newCell` in the `currentlyPlayingIndexPath` didSet block, which will crash when the currentlyPlayingIndexPath changes due to a song finishing, and the cell is off-screen, and thus doesn't exist. Now, I simply make that an optional, so that playerNav.postView will just be nil in that case. If the cell is ever scrolled into view, the `transplantPlayerAndPostViewIfNeeded` function will update playerNav.postView.  